### PR TITLE
Add GitHub Action to check the build for Pull Requests

### DIFF
--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -1,0 +1,38 @@
+# This file describes a GitHub workflow to verify that the code compiles when updating the
+# main branch
+name: CI-main
+
+# Controls when the action will run. Triggers the workflow when pushing to the main branch or
+# when creating a pull request to the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+
+    # This grabs the WPILib docker container. It will need to be updated for each season to ensure
+    # it is building with the correct season's wpilib code.
+    container: wpilib/roborio-cross-ubuntu:2025-22.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v4
+    # Declares the repository safe and not under dubious ownership.
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+    # Grant execute permission for gradlew
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    # Runs a single command using the runners shell
+    - name: Compile and run tests on robot code
+      run: ./gradlew build


### PR DESCRIPTION
No need to worry too much about this file, but having this makes it so that every Pull Request that gets created will automatically get built on GitHub to ensure the code compiles. When creating a Pull Request, GitHub will show you while it's building and post the results. A passing build is required to be able to merge to `main`. The goal is to prevent code that doesn't compile from getting merged.

For anyone who is interested, [this page describes in more detail](https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/robot-code-ci.html) about what the parts of the file mean.