### PR TITLE
Add initial framework for FeatherCanDecoder and ICoralIntakeDataProvider

### DIFF
--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -1,0 +1,18 @@
+#include "io/FeatherCanDecoder.h"
+
+FeatherCanDecoder::FeatherCanDecoder() {
+    m_coralIntakeAngleDegrees = 0.0;
+    m_coralCollected = false;
+}
+
+void FeatherCanDecoder::Update() {
+    // @todo Read and unpack the CAN bus data to set m_coralIntakeAngleDegrees and m_coralCollected
+}
+
+float FeatherCanDecoder::GetCoralIntakeAngleDegrees() {
+    return m_coralIntakeAngleDegrees;
+}
+
+bool FeatherCanDecoder::IsCoralCollected() {
+    return m_coralCollected;
+}

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "subsystems/ICoralIntakeDataProvider.h"
+
+class FeatherCanDecoder: public ICoralIntakeDataProvider {
+public:
+    FeatherCanDecoder();
+
+    void Update();
+
+    // **** ICoralIntakeDataProvider interface functions **** //
+    float GetCoralIntakeAngleDegrees() override;
+    bool IsCoralCollected() override;
+
+private:
+    float m_coralIntakeAngleDegrees;
+    bool m_coralCollected;
+};

--- a/src/main/include/subsystems/ICoralIntakeDataProvider.h
+++ b/src/main/include/subsystems/ICoralIntakeDataProvider.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class ICoralIntakeDataProvider {
+public:
+    // Provide the angle of the coral intake/delivery mechanism in degrees
+    // @todo Decide if this will return the raw angle or the offset from some fixed point (like straight out or down)
+    virtual float GetCoralIntakeAngleDegrees() = 0;
+
+    // Return a simple boolean to indicate whether a piece of coral has been collected
+    virtual bool IsCoralCollected() = 0;
+};


### PR DESCRIPTION
This introduces the base framework for the object to read CAN data from the FeatherCAN devices. It also shows an example of an interface that can be used to provide the relevant data for the coral intake mechanism.

The structure here is set up so that we have interface classes that the FeatherCanDecoder will implement to provide the data to other areas of the code that need it. As an example, when the coral intake subsystem is implemented, it will take an object of type `ICoralIntakeDataProvider` in the constructor. Then when it needs to know the angle of the coral intake or whether coral is present, it can call the interface functions to get the data it needs.

Still a lot of work to be done to actually parse the data though. 😄 

Todo:
- [ ] Agree on CAN data structure so we know how to unpack the CAN data from the Feather devices
- [ ] Implement the `Update()` function to read and unpack the CAN data
- [ ] Create the FeatherCanDecoder object in the main robot code
- [ ] Call the `Update()` function from the main robot periodic functions
- [ ] Create the other interface classes that will provide data for other subsystems (e.g. algae collector, distance from reef, climber)