### PR TITLE
Add parsing for the Coral Feather CAN data

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -10,6 +10,8 @@ Robot::Robot() {}
 
 void Robot::RobotPeriodic() {
   frc2::CommandScheduler::GetInstance().Run();
+
+  m_featherCanDecoder.Update();
 }
 
 void Robot::DisabledInit() {}

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -1,12 +1,17 @@
 #include "io/FeatherCanDecoder.h"
 
-FeatherCanDecoder::FeatherCanDecoder() {
+#include "frc/smartdashboard/SmartDashboard.h"
+
+FeatherCanDecoder::FeatherCanDecoder():m_coralCAN(kCoralCanID)
+{
     m_coralIntakeAngleDegrees = 0.0;
     m_coralCollected = false;
 }
 
 void FeatherCanDecoder::Update() {
-    // @todo Read and unpack the CAN bus data to set m_coralIntakeAngleDegrees and m_coralCollected
+    UnpackCoralCANData();
+
+    frc::SmartDashboard::PutNumber("Angles of Coral FeatherCan", m_coralIntakeAngleDegrees);
 }
 
 float FeatherCanDecoder::GetCoralIntakeAngleDegrees() {
@@ -15,4 +20,15 @@ float FeatherCanDecoder::GetCoralIntakeAngleDegrees() {
 
 bool FeatherCanDecoder::IsCoralCollected() {
     return m_coralCollected;
+}
+
+void FeatherCanDecoder::UnpackCoralCANData() {
+    frc::CANData data;
+
+    bool isCoralDataValid = m_coralCAN.ReadPacketNew(kCoralAPIId, &data);
+
+    if (isCoralDataValid) {
+        int angleX10 = (data.data[0] << 8) | data.data[1];
+        m_coralIntakeAngleDegrees = angleX10 / 10.0;
+    }
 }

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -2,7 +2,7 @@
 
 #include "frc/smartdashboard/SmartDashboard.h"
 
-FeatherCanDecoder::FeatherCanDecoder():m_coralCAN(kCoralCanID)
+FeatherCanDecoder::FeatherCanDecoder():m_coralCAN(kCoralDeviceID)
 {
     m_coralIntakeAngleDegrees = 0.0;
     m_coralCollected = false;

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -2,8 +2,14 @@
 
 #include "subsystems/ICoralIntakeDataProvider.h"
 
+#include <frc/CAN.h>
+
+
 class FeatherCanDecoder: public ICoralIntakeDataProvider {
 public:
+    const int kCoralCanID = 1;
+    const int kCoralAPIId = 1;
+
     FeatherCanDecoder();
 
     void Update();
@@ -15,4 +21,7 @@ public:
 private:
     float m_coralIntakeAngleDegrees;
     bool m_coralCollected;
+    frc::CAN m_coralCAN;
+
+    void UnpackCoralCANData();
 };

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -7,7 +7,7 @@
 
 class FeatherCanDecoder: public ICoralIntakeDataProvider {
 public:
-    const int kCoralCanID = 1;
+    const int kCoralDeviceID = 1;
     const int kCoralAPIId = 1;
 
     FeatherCanDecoder();


### PR DESCRIPTION
This is from the Saturday work for reading a feather CAN attached to a REV throughbore encoder. I had to make just a few changes after @Jsgsfsbw and @saachiKha left. But this is capable of reading the angle from the Feather CAN responsible for the coral mechanism.