### PR TITLE
Add skeleton framework for coordinating the scoring subsystems

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -6,7 +6,9 @@
 
 #include <frc2/command/CommandScheduler.h>
 
-Robot::Robot() {}
+Robot::Robot():
+  m_container(&m_featherCanDecoder)
+{}
 
 void Robot::RobotPeriodic() {
   frc2::CommandScheduler::GetInstance().Run();

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -8,7 +8,10 @@
 #include <frc2/command/Commands.h>
 #include <pathplanner/lib/auto/AutoBuilder.h>
 
-RobotContainer::RobotContainer()
+RobotContainer::RobotContainer(FeatherCanDecoder* featherCanDecoder):
+    m_featherCanDecoder(featherCanDecoder),
+    m_coralSubsystem(m_featherCanDecoder),
+    m_scoringSuperstructure(m_elevatorSubsystem, m_coralSubsystem)
 {
     m_autoChooser = pathplanner::AutoBuilder::buildAutoChooser("Tests");
     frc::SmartDashboard::PutData("Auto Mode", &m_autoChooser);

--- a/src/main/cpp/subsystems/ElevatorSubsystem.cpp
+++ b/src/main/cpp/subsystems/ElevatorSubsystem.cpp
@@ -41,4 +41,10 @@ void ElevatorSubsystem::Periodic() {
 void ElevatorSubsystem::PlotElevatorPosition() {
     ctre::phoenix6::StatusSignal<units::turn_t> position = m_elevatorMotor1.GetPosition();
     frc::SmartDashboard::PutNumber("Elevator Motor Position", position.GetValue().value());
+};
+
+frc2::CommandPtr ElevatorSubsystem::SetPositionCommand(units::inch_t position) {
+    return frc2::cmd::RunOnce([this, position] {
+            // @todo Implement the command to move the elevator to the given position
+        });
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -1,0 +1,49 @@
+#include "subsystems/ScoringSuperstructure.h"
+
+using namespace subsystems;
+
+ScoringSuperstructure::ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech):
+    m_elevator(elevator),
+    m_coralMech(coralMech)
+{
+}
+
+frc2::CommandPtr ScoringSuperstructure::StowCommand() {
+    return frc2::cmd::Parallel(
+        m_elevator.SetPositionCommand(kElevatorStowPosition)
+
+        // @todo Add other parallel commands to stow the coral and algae subsystems
+    ).WithName("Stow");
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreCoralL1Command() {
+    return frc2::cmd::Parallel(
+        m_elevator.SetPositionCommand(kElevatorL1Position)
+
+        // @todo Add other commands to position the coral and algae subsystems
+    ).WithName("ScoreL1");
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreCoralL2Command() {
+    return frc2::cmd::Parallel(
+        m_elevator.SetPositionCommand(kElevatorL2Position)
+
+        // @todo Add other commands to position the coral and algae subsystems
+    ).WithName("ScoreL2");
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreCoralL3Command() {
+    return frc2::cmd::Parallel(
+        m_elevator.SetPositionCommand(kElevatorL3Position)
+
+        // @todo Add other commands to position the coral and algae subsystems
+    ).WithName("ScoreL3");
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreCoralL4Command() {
+    return frc2::cmd::Parallel(
+        m_elevator.SetPositionCommand(kElevatorL4Position)
+
+        // @todo Add other commands to position the coral and algae subsystems
+    ).WithName("ScoreL4");
+}

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -7,8 +7,12 @@
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/CommandPtr.h>
 #include <frc2/command/button/CommandXboxController.h>
+#include "io/FeatherCanDecoder.h"
 #include "subsystems/CommandSwerveDrivetrain.h"
 #include "subsystems/CameraSubsystem.h"
+#include "subsystems/ElevatorSubsystem.h"
+#include "subsystems/CoralSubsystem.h"
+#include "subsystems/ScoringSuperstructure.h"
 #include "Telemetry.h"
 #include <frc2/command/RunCommand.h>
 
@@ -33,7 +37,12 @@ private:
 
     frc2::CommandXboxController m_joystick{0};
 
+    // Robot.cpp owns the FeatherCanDecoder object
+    FeatherCanDecoder* m_featherCanDecoder;
     CameraSubsystem m_cameraSubsystem;
+    ElevatorSubsystem m_elevatorSubsystem;
+    CoralSubsystem m_coralSubsystem;
+    subsystems::ScoringSuperstructure m_scoringSuperstructure;
 
 public:
     subsystems::CommandSwerveDrivetrain m_drivetrain{TunerConstants::CreateDrivetrain()};
@@ -43,7 +52,7 @@ private:
     frc::SendableChooser<frc2::Command *> m_autoChooser;
 
 public:
-    RobotContainer();
+    RobotContainer(FeatherCanDecoder* featherCanDecoder);
 
     frc2::Command *GetAutonomousCommand();
 

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -1,19 +1,34 @@
+#pragma once
+
+#include <frc2/command/Commands.h>
 #include <frc2/command/SubsystemBase.h>
 #include <ctre/phoenix6/TalonFX.hpp>
 #include <string>
 #include <iostream>
 #include <frc/DigitalInput.h>
+#include <units/length.h>
 
 // @todo Set these to the correct IDs when they are assigned on the real robot
 constexpr int kElevatorMotor1Id = 20;
 constexpr int kElevatorMotor2Id = 19;
 constexpr int kLimitSwitchId = 18;
 
+// @todo Assign these to real values when we know the distances
+constexpr units::inch_t kElevatorStowPosition = 0_in;
+constexpr units::inch_t kElevatorL1Position = 0_in;
+constexpr units::inch_t kElevatorL2Position = 0_in;
+constexpr units::inch_t kElevatorL3Position = 0_in;
+constexpr units::inch_t kElevatorL4Position = 0_in;
+
 class ElevatorSubsystem : public frc2::SubsystemBase {
     public:
         ElevatorSubsystem();
+
         void Periodic() override;
         void PlotElevatorPosition();
+
+        frc2::CommandPtr SetPositionCommand(units::inch_t position);
+
     private:
         ctre::phoenix6::hardware::TalonFX m_elevatorMotor1;
         ctre::phoenix6::hardware::TalonFX m_elevatorMotor2;

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <frc2/command/Commands.h>
+#include <frc2/command/SubsystemBase.h>
+#include "subsystems/CoralSubsystem.h"
+#include "subsystems/ElevatorSubsystem.h"
+
+namespace subsystems {
+
+class ScoringSuperstructure : public frc2::SubsystemBase {
+    public:
+        // @todo This will also need to include the CoralSubsystem and AlgaeSubsystem when they are ready
+        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech);
+
+        // Command to return all components to their idle positions
+        frc2::CommandPtr StowCommand();
+        frc2::CommandPtr ScoreCoralL1Command();
+        frc2::CommandPtr ScoreCoralL2Command();
+        frc2::CommandPtr ScoreCoralL3Command();
+        frc2::CommandPtr ScoreCoralL4Command();
+
+    private:
+        ElevatorSubsystem& m_elevator;
+        CoralSubsystem& m_coralMech;
+};
+
+}


### PR DESCRIPTION
We haven't had a lot of time to discuss the architecture for coordinating the subsystems. I took inspiration from @VG-Fish's architecture diagram to put together a suggested framework for being able to coordinate the different subsystems. Since we're running short on time, I wanted to get this over to you so you can get it filled out with the guts to make things move.

What do you think of the `ScoringSuperstructure` approach of having it build inline commands coordinate the elevator, coral and algae mechanisms?