### PR TITLE
Update coral mechanism to be able to hold a specific angle

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -50,16 +50,22 @@ void RobotContainer::ConfigureBindings() {
 
     m_joystick.POVDown().OnTrue(frc2::cmd::RunOnce([this] { m_drivetrain.SeedFieldCentric(); }));
 
+    m_joystick.B().OnTrue(
+        frc2::cmd::RunOnce([this] {
+            m_coralSubsystem.GoToAngle(90.0);
+        })
+    );
+    m_joystick.A().OnTrue(
+        frc2::cmd::RunOnce([this] {
+            m_coralSubsystem.GoToAngle(135.0);
+        })
+    );
+
     m_joystick.X().OnTrue(
-        m_elevatorSubsystem.Lower()
+        m_coralSubsystem.collectCoral()
     );
     m_joystick.Y().OnTrue(
-        // m_elevatorSubsystem.Raise()
-        m_elevatorSubsystem.SetPositionCommand(5_in)
-    );
-    
-    m_joystick.A().OnTrue(
-        m_elevatorSubsystem.Stop()
+        m_coralSubsystem.dispenseCoral()
     );
 }
 

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -11,8 +11,8 @@ FeatherCanDecoder::FeatherCanDecoder():m_coralCAN(kCoralDeviceID)
 void FeatherCanDecoder::Update() {
     UnpackCoralCANData();
 
-    frc::SmartDashboard::PutNumber("Raw Angle of Coral FeatherCan", m_coralIntakeAngleDegrees);
-    frc::SmartDashboard::PutNumber("Angle of Coral FeatherCan", m_coralIntakeAngleDegrees + kCoralAngleOffsetDegrees);
+    frc::SmartDashboard::PutNumber("Raw Angle of Coral FeatherCan", GetCoralIntakeRawAngleDegrees());
+    frc::SmartDashboard::PutNumber("Angle of Coral FeatherCan", GetCoralIntakeAngleDegrees());
     frc::SmartDashboard::PutBoolean("Coral Collected?", m_coralCollected);
 }
 

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -10,7 +10,7 @@ public:
     const int kCoralDeviceID = 1;
     const int kCoralAPIId = 1;
     const int kCoralProximityThreshold = 1500;
-    const double kCoralAngleOffsetDegrees = 262.6;
+    const double kCoralAngleOffsetDegrees = -262.6;
 
     FeatherCanDecoder();
 

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -12,12 +12,14 @@ class CoralSubsystem : public frc2::SubsystemBase {
  public:
   CoralSubsystem(ICoralIntakeDataProvider* dataProvider);
 
+  void Periodic() override;
+
   void SetIntakeSpeed(double speed);
   void SetPivotSpeed(double speed);
 
   bool CoralPresent();
 
-  frc2::CommandPtr GoToAngle(double angle);
+  void GoToAngle(double angle);
   frc2::CommandPtr collectCoral();
   frc2::CommandPtr dispenseCoral();
 


### PR DESCRIPTION
This is the work we got through this evening to allow the coral mechanism to hold its position. The important change here is that `GoToAngle` only saves the setpoint. It is now up to the `Periodic` function (which runs every 20 ms) to run the PID to calculate the motor speed necessary to hold its position. This means it will also return to its position if it is moved slightly.

The `m_coralPID` still needs to be tuned (and possibly switched to the `ProfiledPIDController` class) to get it to the desired angle quickly, reliably and without a lot of oscillation.