### PR TITLE
Align with any side of the reef

### DIFF
--- a/src/main/cpp/commands/AlignWithReef.cpp
+++ b/src/main/cpp/commands/AlignWithReef.cpp
@@ -10,33 +10,70 @@ AlignWithReef::AlignWithReef(CameraSubsystem* camera, subsystems::CommandSwerveD
     // Register that this command requires the subsystem.
     AddRequirements(m_drivetrain);
     AddRequirements(m_camera);
+
+    m_rotationalPID.EnableContinuousInput(-180.0, 180.0);
 }
 
 void AlignWithReef::Initialize() {
+    m_targetTagId = m_camera->GetTargetTagId();
+
+    // If a target tag exists and it is in the reef tag list, then we should attempt to align to it
+    if (m_targetTagId && kTagAngleMap.contains(m_targetTagId.value())) {
+        m_targetDegrees = kTagAngleMap.at(m_targetTagId.value());
+    } else {
+        m_targetTagId = std::nullopt;
+    }
 }
 
 void AlignWithReef::Execute() {
-    double forward = m_XAlignmentPID.Calculate(m_distanceFromReefSetpoint.value(), m_camera->getForwardTransformation().value());
-    double strafe = m_YAlignmentPID.Calculate(m_strafeSetpoint.value(), m_camera->getStrafeTransformation().value());
-    double rotation = m_angularAlignmentPID.Calculate(m_rotationalSetpoint, units::radian_t(m_camera->getZRotation()));
+    if (!m_targetTagId) {
+        // No target exists, so don't attempt to align
+        return;
+    }
+
+    double forward = m_XAlignmentPID.Calculate(m_camera->getForwardTransformation().value(), kDistanceFromReefSetpoint.value());
+    forward = std::clamp(forward, -1.0, 1.0);
+
+    units::meter_t forward_diff = units::math::abs(kDistanceFromReefSetpoint - m_camera->getForwardTransformation());
+    if (forward_diff < kForwardTolerance) {
+        forward = 0.0;
+    }
+
+    double strafe = m_YAlignmentPID.Calculate(m_camera->getStrafeTransformation().value(), kStrafeSetpoint.value());
+    strafe = std::clamp(strafe, -1.0, 1.0);
+
+    units::meter_t strafe_diff = units::math::abs(kStrafeSetpoint - m_camera->getStrafeTransformation());
+    if (strafe_diff < kStrafeTolerance) {
+        strafe = 0.0;
+    }
+
+    units::degree_t currentDegrees = m_drivetrain->GetState().Pose.Rotation().Degrees();
+    double rotation = m_rotationalPID.Calculate(currentDegrees.value(), m_targetDegrees.value());
+    rotation = std::clamp(rotation, -1.0, 1.0);
 
     frc::SmartDashboard::PutNumber("Strafe PID", strafe);
     frc::SmartDashboard::PutNumber("Forward PID", forward);
     frc::SmartDashboard::PutNumber("Rotation PID", rotation);
-    m_drivetrain->SetControl(robotOriented.WithVelocityX(units::meters_per_second_t(forward))
-                                          .WithVelocityY(units::meters_per_second_t(strafe))
-                                          .WithRotationalRate(-units::radians_per_second_t(rotation)));
+
+    m_drivetrain->SetControl(robotOriented.WithVelocityX(-forward * kMaxVelocity)
+                                          .WithVelocityY(-strafe * kMaxVelocity)
+                                          .WithRotationalRate(rotation * kMaxAngularVelocity));
 }
 
 bool AlignWithReef::IsFinished() {
-    units::meter_t forward_diff = units::math::abs(m_distanceFromReefSetpoint - m_camera->getForwardTransformation());
-    units::meter_t strafe_diff = units::math::abs(m_strafeSetpoint - m_camera->getStrafeTransformation());
-    units::radian_t rotational_diff = units::math::abs(m_rotationalSetpoint - m_camera->getZRotation());
+    if (!m_targetTagId) {
+        // If there is no target tag, finish the command immediately
+        return true;
+    }
+
+    units::meter_t forward_diff = units::math::abs(kDistanceFromReefSetpoint - m_camera->getForwardTransformation());
+    units::meter_t strafe_diff = units::math::abs(kStrafeSetpoint - m_camera->getStrafeTransformation());
+    units::degree_t currentDegrees = m_drivetrain->GetState().Pose.Rotation().Degrees();
+    units::degree_t rotational_diff = units::math::abs(currentDegrees - m_targetDegrees);
 
     // If the bot is within tolerance for X, Y and rotational position, then we consider the command finished.
     // If we lose the ability to see the tag, also end the command.
-    return ((strafe_diff < kStrafeTolerance
+    return (strafe_diff < kStrafeTolerance
                 && forward_diff < kForwardTolerance
-                && rotational_diff < units::radian_t(kRotationTolerance))
-            || m_camera->visibleTargets() == false);
+                && rotational_diff < kRotationTolerance);
 }

--- a/src/main/cpp/subsystems/CameraSubsystem.cpp
+++ b/src/main/cpp/subsystems/CameraSubsystem.cpp
@@ -31,6 +31,14 @@ void CameraSubsystem::updateData() {
     }
 }
 
+std::optional<int> CameraSubsystem::GetTargetTagId() {
+    if (visibleTargets()) {
+        return bestTarget.GetFiducialId();
+    } else {
+        return std::nullopt;
+    }
+}
+
 //Returns true if targets are visible to limelight. Otherwise returns false
 bool CameraSubsystem::visibleTargets() {
     return result.HasTargets();

--- a/src/main/include/commands/AlignWithReef.h
+++ b/src/main/include/commands/AlignWithReef.h
@@ -38,31 +38,43 @@ private:
     CameraSubsystem* m_camera;
     subsystems::CommandSwerveDrivetrain* m_drivetrain;
 
-    static constexpr double kP = 1.0;
-    static constexpr double kI = 0.1;
+    std::optional<int> m_targetTagId;
+    units::degree_t m_targetDegrees;
+
+    static constexpr double kP = 2.0;
+    static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
     frc::PIDController m_YAlignmentPID {kP, kI, kD};
 
-    static constexpr units::radians_per_second_t kMaxAngularVelocity = 1.0_rad_per_s;
-    static constexpr units::turns_per_second_squared_t kMaxAngularAcceleration = 1.0_rad_per_s_sq;
-    static constexpr double kRotationP = 1.0;
-    static constexpr double kRotationI = 0.1;
+    static constexpr double kRotationP = 0.05;
+    static constexpr double kRotationI = 0.0;
     static constexpr double kRotationD = 0.0;
+    frc::PIDController m_rotationalPID {kRotationP, kRotationI, kRotationD};
 
-    frc::TrapezoidProfile<units::radians>::Constraints m_angularConstraints {
-        kMaxAngularVelocity, kMaxAngularAcceleration
-    };
-    frc::ProfiledPIDController<units::radians> m_angularAlignmentPID {
-        kRotationP, kRotationI, kRotationD, m_angularConstraints
-    };
+    static constexpr units::meters_per_second_t kMaxVelocity = 0.75_mps;
+    static constexpr units::radians_per_second_t kMaxAngularVelocity = 1.0_rad_per_s;
 
     const units::meter_t kForwardTolerance = units::meter_t(2_in);
-    const units::meter_t kStrafeTolerance = units::meter_t(2_in);
-    const units::degree_t kRotationTolerance = 3_deg;
+    const units::meter_t kStrafeTolerance = units::meter_t(1_in);
+    const units::degree_t kRotationTolerance = 2_deg;
 
-    units::meter_t m_distanceFromReefSetpoint = units::meter_t(48_in);
-    units::meter_t m_strafeSetpoint = units::meter_t(0_in);
-    units::radian_t m_rotationalSetpoint = 0_rad;
+    units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
+    units::meter_t kStrafeSetpoint = units::meter_t(-1_in);
+
+    const std::map<int, units::degree_t> kTagAngleMap = {
+        {6, 120_deg},
+        {7, 180_deg},
+        {8, 240_deg},
+        {9, 300_deg},
+        {10, 0_deg},
+        {11, 60_deg},
+        {17, 60_deg},
+        {18, 0_deg},
+        {19, 300_deg},
+        {20, 240_deg},
+        {21, 180_deg},
+        {22, 120_deg},
+    };
 };

--- a/src/main/include/subsystems/CameraSubsystem.h
+++ b/src/main/include/subsystems/CameraSubsystem.h
@@ -23,6 +23,8 @@ class CameraSubsystem : public frc2::SubsystemBase {
   double getDistance();
   units::degree_t getZRotation();
 
+  std::optional<int> GetTargetTagId();
+
   void Periodic() override;
 
  private:


### PR DESCRIPTION
This adds the ability to line up with any side of the reef. Instead of aligning with the detected angle of the tag, this figures out the angle based on the tag ID to attempt to reduce the errors based on vision based measurements.