### PR TITLE
Scoring updates

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -12,13 +12,15 @@
 #include <pathplanner/lib/auto/AutoBuilder.h>
 #include <pathplanner/lib/auto/NamedCommands.h>
 
+using namespace subsystems;
+
 RobotContainer::RobotContainer(FeatherCanDecoder* featherCanDecoder):
 m_featherCanDecoder(featherCanDecoder),
 m_cameraSubsystem(&m_drivetrain),
 m_coralSubsystem(m_featherCanDecoder),
 m_algaeSubsystem(m_featherCanDecoder),
 m_climberSubsystem(m_featherCanDecoder),
-m_scoringSuperstructure(m_elevatorSubsystem, m_coralSubsystem, m_algaeSubsystem)
+m_scoringSuperstructure(m_elevatorSubsystem, m_coralSubsystem, m_algaeSubsystem, m_drivetrain)
 {
     m_autoChooser = pathplanner::AutoBuilder::buildAutoChooser("Tests");
     frc::SmartDashboard::PutData("Auto Mode", &m_autoChooser);
@@ -52,76 +54,90 @@ void RobotContainer::ConfigureBindings() {
 
     m_drivetrain.RegisterTelemetry([this](auto const &state) { logger.Telemeterize(state); });
 
-    // **** Driver Station Buttons **** //
-
     m_joystick.POVRight().WhileTrue(
-        m_drivetrain.ApplyRequest([this] -> auto&& {
+        m_drivetrain.ApplyRequest([this]() -> auto&& {
             return strafe.WithVelocityY(-0.25_mps);
         })
     );
 
     m_joystick.POVLeft().WhileTrue(
-        m_drivetrain.ApplyRequest([this] -> auto&& {
+        m_drivetrain.ApplyRequest([this]() -> auto&& {
             return strafe.WithVelocityY(0.25_mps);
         })
     );
 
+    // **** Driver Station Buttons **** //
+
     m_gamepad.Button(7).OnTrue(frc2::cmd::Parallel(
         frc2::cmd::RunOnce([this] {
             m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Coast);
-        }),
-        m_climberSubsystem.Climb()
-    ));
-    
-    m_gamepad.Button(11).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.PrepareElevator(kElevatorL4Position, false);
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::IDK);
-    }));
+        })
 
-    m_gamepad.Button(10).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.PrepareElevator(kElevatorL3Position, true);
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L3);
-    }));
+        // @todo Add a command to move the climber to the Ready To Climb position
+    ));
+
+    m_gamepad.Button(11).OnTrue(
+        frc2::cmd::Parallel(
+            m_scoringSuperstructure.PrepareScoring(ScoringSuperstructure::ScoringSelector::L4),
+            frc2::cmd::RunOnce([this] {
+                m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::IDK);
+            })
+        ));
+
+    m_gamepad.Button(10).OnTrue(
+        frc2::cmd::Parallel(
+            m_scoringSuperstructure.PrepareScoring(ScoringSuperstructure::ScoringSelector::L3AlgaeAndCoral),
+            frc2::cmd::RunOnce([this] {
+                m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L3);
+            })
+        ));
 
     // TODO: change the name of ALGAE_HELD
-    m_gamepad.Button(9).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.PrepareElevator(kElevatorL3Position, true);
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ALGAE_HELD);
-    }));
+    m_gamepad.Button(9).OnTrue(frc2::cmd::Parallel(
+        m_scoringSuperstructure.PrepareScoring(ScoringSuperstructure::ScoringSelector::L3AlgaeOnly),
+        frc2::cmd::RunOnce([this] {
+            m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ALGAE_HELD);
+        })
+    ));
 
-    m_gamepad.Button(6).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.PrepareElevator(kElevatorL2Position, false);
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L2);
-    }));
+    m_gamepad.Button(6).OnTrue(frc2::cmd::Parallel(
+        m_scoringSuperstructure.PrepareScoring(ScoringSuperstructure::ScoringSelector::L2),
+        frc2::cmd::RunOnce([this] {
+            m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L2);
+        })
+    ));
 
+    m_gamepad.Button(1).OnTrue(frc2::cmd::Parallel(
+        m_scoringSuperstructure.PrepareScoring(ScoringSuperstructure::ScoringSelector::L1),
+        frc2::cmd::RunOnce([this] {
+            m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L1);
+        })
+    ));
 
-    m_gamepad.Button(1).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.PrepareElevator(kElevatorL1Position, false);
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L1);
-    }));
+    m_gamepad.Button(2).OnTrue(
+        m_scoringSuperstructure.ToStowPosition()
+    );
 
-    m_gamepad.Button(2).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.ToStowPosition();
-    }));
-
-    m_gamepad.Button(3).OnTrue(frc2::cmd::RunOnce([this] {
-        m_scoringSuperstructure.ToCollectPosition();
-        m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L1);
-    }));
+    m_gamepad.Button(3).OnTrue(frc2::cmd::Parallel(
+        m_scoringSuperstructure.ToCollectPosition(),
+        frc2::cmd::RunOnce([this] {
+            m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::ELEVATOR_L1);
+        })
+    ));
 
     // **** Xbox A, B, X, & Y Button functions **** //
     m_joystick.B().WhileTrue(AlignWithReef(&m_cameraSubsystem, &m_drivetrain).ToPtr());
 
     m_joystick.X().WhileTrue(m_scoringSuperstructure.ScoreIntoProcessor());
-  
+
     // **** Xbox Trigger & Bumper Buttons **** //
     m_joystick.RightTrigger()
         .OnTrue(
             m_scoringSuperstructure.ScoreIntoReef()
-        )
-        .OnFalse(
-            m_elevatorSubsystem.GoToHeight(m_elevatorSubsystem.CurrentHeight())
         );
+        // .OnFalse(
+        //     m_elevatorSubsystem.GoToHeight(m_elevatorSubsystem.CurrentHeight())
+        // );
 
     m_joystick.LeftTrigger().OnTrue(
         m_coralSubsystem.collectCoral()
@@ -149,35 +165,35 @@ frc2::Command *RobotContainer::GetAutonomousCommand()
 void RobotContainer::AddPathPlannerCommands() {
     using namespace pathplanner;
     NamedCommands::registerCommand(
-        "Stow", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorStowPosition, false))
+        "Stow",
+        std::move(m_scoringSuperstructure.ToStowPosition())
     );
     NamedCommands::registerCommand(
-        "Collect", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorCollectPosition, false))
+        "Collect",
+        std::move(m_scoringSuperstructure.ToCollectPosition())
     );
     NamedCommands::registerCommand(
-        "ScoreL1", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorL1Position, false))
+        "ScoreL1",
+        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(ScoringSuperstructure::ScoringSelector::L1))
     );
     NamedCommands::registerCommand(
-        "ScoreL2", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorL2Position, false))
+        "ScoreL2",
+        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(ScoringSuperstructure::ScoringSelector::L2))
     );
     NamedCommands::registerCommand(
-        "ScoreL3", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorL3Position, false))
+        "ScoreL3",
+        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(ScoringSuperstructure::ScoringSelector::L3AlgaeAndCoral))
     );
     NamedCommands::registerCommand(
-        "ScoreL4", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorL4Position, false))
+        "ScoreL4",
+        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(ScoringSuperstructure::ScoringSelector::L4))
     );
     NamedCommands::registerCommand(
-        "ScoreL3AndRemoveAlgae", 
-        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(kElevatorL3Position, true))
+        "ScoreL3AndRemoveAlgae",
+        std::move(m_scoringSuperstructure.PrepareAndScoreIntoReef(ScoringSuperstructure::ScoringSelector::L3AlgaeAndCoral))
     );
     NamedCommands::registerCommand(
-        "ScoreAlgae", 
+        "ScoreAlgae",
         std::move(m_scoringSuperstructure.ScoreIntoProcessor())
     );
 }

--- a/src/main/cpp/commands/DriveBackAfterScore.cpp
+++ b/src/main/cpp/commands/DriveBackAfterScore.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "commands/DriveBackAfterScore.h"
+
+DriveBackAfterScore::DriveBackAfterScore(subsystems::CommandSwerveDrivetrain* drivetrain)
+    : m_drivetrain{drivetrain} {
+    AddRequirements(m_drivetrain);
+}
+
+void DriveBackAfterScore::Initialize() {
+    m_targetX = kBackwardDistance + m_drivetrain->GetState().Pose.X();
+}
+
+void DriveBackAfterScore::Execute() {
+    units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
+    double forward = m_XAlignmentPID.Calculate(m_targetX.value(), currentXDistance.value());
+    forward = std::clamp(forward, -1.0, 1.0);
+
+    m_drivetrain->SetControl(robotOriented.WithVelocityX(forward * kMaxVelocity));
+}
+
+bool DriveBackAfterScore::IsFinished() {
+    units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
+    return units::math::abs(currentXDistance - m_targetX) < kTolerance;
+}

--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "commands/DriveForwardToScore.h"
+
+#include <frc/smartdashboard/SmartDashboard.h>
+
+DriveForwardToScore::DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain)
+    : m_drivetrain{drivetrain} {
+    AddRequirements(m_drivetrain);
+}
+
+void DriveForwardToScore::Initialize() {
+    m_targetX = kForwardDistance + m_drivetrain->GetState().Pose.X();
+}
+
+void DriveForwardToScore::Execute() {
+    units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
+    frc::SmartDashboard::PutNumber("Drive Forward Current X", currentXDistance.value());
+    double forward = m_XAlignmentPID.Calculate(m_targetX.value(), currentXDistance.value());
+    forward = std::clamp(forward, -1.0, 1.0);
+
+    m_drivetrain->SetControl(robotOriented.WithVelocityX(-forward * kMaxVelocity));
+}
+
+bool DriveForwardToScore::IsFinished() {
+    units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
+    return units::math::abs(currentXDistance - m_targetX) < kTolerance;
+}

--- a/src/main/cpp/subsystems/ElevatorSubsystem.cpp
+++ b/src/main/cpp/subsystems/ElevatorSubsystem.cpp
@@ -93,21 +93,12 @@ void ElevatorSubsystem::SetMotorVoltage() {
         m_elevatorMotor2.SetVoltage(kG);
         elevatorAtHeight = true;
     }
-    frc::SmartDashboard::PutNumber("Elevator diff", current_difference);
 }
 
 frc2::CommandPtr ElevatorSubsystem::GoToHeight(units::inch_t height) {
     return frc2::cmd::RunOnce([this, height] {
         m_setpointHeight = height;
     });
-}
-
-void ElevatorSubsystem::PrepareElevator(units::inch_t newPosition) {
-    m_desiredElevatorPosition = newPosition;
-}
-
-frc2::CommandPtr ElevatorSubsystem::GoToSavedPosition() {
-    return GoToHeight(m_desiredElevatorPosition);
 }
 
 bool ElevatorSubsystem::GetElevatorHeightAboveThreshold() {

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -1,29 +1,67 @@
 #include "subsystems/ScoringSuperstructure.h"
+#include "commands/DriveForwardToScore.h"
+#include "commands/DriveBackAfterScore.h"
+
+#include <frc/smartdashboard/SmartDashboard.h>
 
 using namespace subsystems;
 
 ScoringSuperstructure::ScoringSuperstructure(
-    ElevatorSubsystem& elevator, 
-    CoralSubsystem& coralMech, 
-    AlgaeSubsystem& algaeMech
+    ElevatorSubsystem& elevator,
+    CoralSubsystem& coralMech,
+    AlgaeSubsystem& algaeMech,
+    CommandSwerveDrivetrain& drivetrain
 ):
 m_elevator(elevator),
 m_coral(coralMech),
-m_algae(algaeMech)
+m_algae(algaeMech),
+m_drivetrain(drivetrain)
 {}
 
-frc2::CommandPtr ScoringSuperstructure::PrepareElevator(units::inch_t desiredPosition, bool removeAlgae) {
-    return frc2::cmd::RunOnce([this, desiredPosition, removeAlgae] {
-        m_elevatorSetpointHeight = desiredPosition;
-        m_collectAlgae = removeAlgae;
+frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedScore) {
+    return frc2::cmd::RunOnce([this, selectedScore] {
+        m_selectedScore = selectedScore;
     });
 }
 
 frc2::CommandPtr ScoringSuperstructure::ScoreIntoReef() {
-    auto [coralAngle, algaeAngle] = m_elevatorMap[m_elevatorSetpointHeight];
+    return frc2::cmd::Select<ScoringSelector>([this] {
+            return m_selectedScore;
+        },
+        std::pair{L1, ScoreReefL1()},
+        std::pair{L2, ScoreReefL2()},
+        std::pair{L3AlgaeAndCoral, ScoreReefL3(false)},
+        std::pair{L3AlgaeOnly, ScoreReefL3(true)},
+        std::pair{L4, ScoreReefL4()});
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreReefL1() {
+    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL1Position];
 
     return frc2::cmd::Parallel(
-        m_elevator.GoToHeight(m_elevatorSetpointHeight),
+        m_elevator.GoToHeight(kElevatorL1Position),
+        m_coral.GoToAngle(coralAngle),
+        m_elevator.WaitUntilElevatorAtHeight().AndThen(DriveForwardToScore(&m_drivetrain).WithTimeout(kForwardTimeout))
+            .AndThen(m_coral.dispenseCoral()).AndThen(DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout))
+    );
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreReefL2() {
+    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL2Position];
+
+    return frc2::cmd::Parallel(
+        m_elevator.GoToHeight(kElevatorL2Position),
+        m_coral.GoToAngle(coralAngle),
+        m_elevator.WaitUntilElevatorAtHeight().AndThen(DriveForwardToScore(&m_drivetrain).WithTimeout(kForwardTimeout))
+            .AndThen(m_coral.dispenseCoral()).AndThen(DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout))
+    );
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
+    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL3Position];
+
+    return frc2::cmd::Parallel(
+        m_elevator.GoToHeight(kElevatorL3Position),
         m_coral.GoToAngle(coralAngle),
         frc2::cmd::Either(
             frc2::cmd::Sequence(
@@ -31,9 +69,21 @@ frc2::CommandPtr ScoringSuperstructure::ScoreIntoReef() {
                 m_algae.Intake()
             ),
             m_algae.SetGoalAngle(algaeAngle),
-            [this] { return m_collectAlgae; }
+            [this, algaeOnly] { return algaeOnly; }
         ),
-        m_elevator.WaitUntilElevatorAtHeight().AndThen(m_coral.dispenseCoral())
+        m_elevator.WaitUntilElevatorAtHeight().AndThen(DriveForwardToScore(&m_drivetrain).WithTimeout(kForwardTimeout))
+            .AndThen(m_coral.dispenseCoral()).AndThen(DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout))
+    );
+}
+
+frc2::CommandPtr ScoringSuperstructure::ScoreReefL4() {
+    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL2Position];
+
+    return frc2::cmd::Parallel(
+        m_elevator.GoToHeight(kElevatorL2Position),
+        m_coral.GoToAngle(coralAngle),
+        m_elevator.WaitUntilElevatorAtHeight().AndThen(DriveForwardToScore(&m_drivetrain).WithTimeout(kForwardTimeout))
+            .AndThen(m_coral.dispenseCoral()).AndThen(DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout))
     );
 }
 
@@ -52,14 +102,43 @@ frc2::CommandPtr ScoringSuperstructure::ScoreIntoProcessor() {
     );
 }
 
-frc2::CommandPtr ScoringSuperstructure::PrepareAndScoreIntoReef(units::inch_t desiredPosition, bool removeAlgae) {
-    return PrepareElevator(desiredPosition, removeAlgae).AndThen(ScoreIntoReef());
+frc2::CommandPtr ScoringSuperstructure::PrepareAndScoreIntoReef(ScoringSelector selectedScore) {
+    return PrepareScoring(selectedScore).AndThen(ScoreIntoReef());
 }
 
 frc2::CommandPtr ScoringSuperstructure::ToCollectPosition() {
+    return frc2::cmd::Select<bool>([this] {
+            return m_algae.IsAlgaeStored();
+        },
+        std::pair{false,
+            frc2::cmd::Parallel(
+                m_elevator.GoToHeight(kElevatorCollectPosition),
+                m_coral.GoToAngle(kCoralCollect)
+            )},
+        // If algae is detected, don't let the elevator go all the way down because
+        // it hits the bumper
+        std::pair{true,
+            frc2::cmd::Parallel(
+                m_elevator.GoToHeight(kElevatorProcessorPosition),
+                m_coral.GoToAngle(kCoralCollect)
+            )});
     return m_elevator.GoToHeight(m_algae.IsAlgaeStored() ? kElevatorProcessorPosition : kElevatorCollectPosition);
 }
 
 frc2::CommandPtr ScoringSuperstructure::ToStowPosition() {
-    return m_elevator.GoToHeight(m_algae.IsAlgaeStored() ? kElevatorProcessorPosition : kElevatorStowPosition);
+    return frc2::cmd::Select<bool>([this] {
+            return m_algae.IsAlgaeStored();
+        },
+        std::pair{false,
+            frc2::cmd::Parallel(
+                m_elevator.GoToHeight(kElevatorStowPosition),
+                m_coral.GoToAngle(kCoralStow)
+            )},
+        // If algae is detected, don't let the elevator go all the way down because
+        // it hits the bumper
+        std::pair{true,
+            frc2::cmd::Parallel(
+                m_elevator.GoToHeight(kElevatorProcessorPosition),
+                m_coral.GoToAngle(kCoralStow)
+            )});
 }

--- a/src/main/include/commands/AlignWithReef.h
+++ b/src/main/include/commands/AlignWithReef.h
@@ -57,11 +57,11 @@ private:
     static constexpr units::radians_per_second_t kMaxAngularVelocity = 1.0_rad_per_s;
 
     const units::meter_t kForwardTolerance = units::meter_t(2_in);
-    const units::meter_t kStrafeTolerance = units::meter_t(1_in);
+    const units::meter_t kStrafeTolerance = units::meter_t(0.5_in);
     const units::degree_t kRotationTolerance = 2_deg;
 
     units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
-    units::meter_t kStrafeSetpoint = units::meter_t(-1_in);
+    units::meter_t kStrafeSetpoint = units::meter_t(-2_in);
 
     const std::map<int, units::degree_t> kTagAngleMap = {
         {6, 120_deg},

--- a/src/main/include/commands/DriveBackAfterScore.h
+++ b/src/main/include/commands/DriveBackAfterScore.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <frc2/command/Command.h>
+#include <frc2/command/CommandHelper.h>
+
+#include "subsystems/CommandSwerveDrivetrain.h"
+
+#include <frc/controller/PIDController.h>
+
+class DriveBackAfterScore
+    : public frc2::CommandHelper<frc2::Command, DriveBackAfterScore> {
+public:
+    explicit DriveBackAfterScore(subsystems::CommandSwerveDrivetrain* drivetrain);
+    void Initialize() override;
+    void Execute() override;
+    bool IsFinished() override;
+
+    swerve::requests::RobotCentric robotOriented = swerve::requests::RobotCentric{}
+        .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
+        .WithVelocityY(0_mps)
+        .WithRotationalRate(0_rad_per_s);
+
+private:
+    subsystems::CommandSwerveDrivetrain* m_drivetrain;
+
+    static constexpr double kP = 1.0;
+    static constexpr double kI = 0.0;
+    static constexpr double kD = 0.0;
+    static constexpr units::meters_per_second_t kMaxVelocity = 0.25_mps;
+
+    frc::PIDController m_XAlignmentPID {kP, kI, kD};
+
+    const units::inch_t kTolerance = 1_in;
+    const units::inch_t kBackwardDistance = 6_in;
+    units::inch_t m_targetX;
+};

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <frc2/command/Command.h>
+#include <frc2/command/CommandHelper.h>
+
+#include "subsystems/CommandSwerveDrivetrain.h"
+
+#include <frc/controller/PIDController.h>
+
+class DriveForwardToScore
+    : public frc2::CommandHelper<frc2::Command, DriveForwardToScore> {
+public:
+    explicit DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain);
+    void Initialize() override;
+    void Execute() override;
+    bool IsFinished() override;
+
+    swerve::requests::RobotCentric robotOriented = swerve::requests::RobotCentric{}
+        .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
+        .WithVelocityY(0_mps)
+        .WithRotationalRate(0_rad_per_s);
+
+private:
+    subsystems::CommandSwerveDrivetrain* m_drivetrain;
+
+    static constexpr double kP = 1.0;
+    static constexpr double kI = 0.0;
+    static constexpr double kD = 0.0;
+    static constexpr units::meters_per_second_t kMaxVelocity = 0.25_mps;
+
+    frc::PIDController m_XAlignmentPID {kP, kI, kD};
+
+    const units::inch_t kTolerance = 2_in;
+    const units::inch_t kForwardDistance = 4_in;
+    units::inch_t m_targetX;
+};

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -8,6 +8,7 @@
 #include <frc/controller/PIDController.h>
 #include "subsystems/ICoralIntakeDataProvider.h"
 
+constexpr units::degree_t kCoralCollect = 150.0_deg;
 constexpr units::degree_t kCoralStow = 160.0_deg;
 constexpr units::degree_t kCoralL1 = 65.0_deg;
 constexpr units::degree_t kCoralL2 = 55.0_deg;

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -45,7 +45,6 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
 
         void PrepareElevator(units::inch_t newPosition);
         frc2::CommandPtr GoToHeight(units::inch_t height);
-        frc2::CommandPtr GoToSavedPosition();
 
         const units::inch_t WHEEL_RADIUS = 1.325_in;
         // 9 to 1
@@ -97,6 +96,4 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
         // Changing m_setpointHeight will send the elevator to that position immediately
         units::inch_t m_setpointHeight = 0_in;
 
-        // Use m_desiredElevatorPosition when preparing the elevator for a call to GoToSavedPosition()
-        units::inch_t m_desiredElevatorPosition;
 };

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -71,8 +71,13 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
 
         static constexpr double TOLERANCE = 0.5;
 
-        static constexpr units::meters_per_second_t kMaxVelocity = 5.0_mps;
-        static constexpr units::meters_per_second_squared_t kMaxAcceleration = 8.0_mps_sq;
+        // @todo Re-adjust the elevator speeds. We slowed them down because raising
+        //  lowering wasn't very smooth in recent tests. It's still unclear what
+        //  is causing that.
+        // static constexpr units::meters_per_second_t kMaxVelocity = 5.0_mps;
+        // static constexpr units::meters_per_second_squared_t kMaxAcceleration = 8.0_mps_sq;
+        static constexpr units::meters_per_second_t kMaxVelocity = 1.0_mps;
+        static constexpr units::meters_per_second_squared_t kMaxAcceleration = 2.0_mps_sq;
         static constexpr double kP = 20.0;
         static constexpr double kI = 0.5;
         static constexpr double kD = 2.0;

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -61,6 +61,8 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         frc2::CommandPtr ScoreReefL2();
         frc2::CommandPtr ScoreReefL3(bool algaeOnly);
         frc2::CommandPtr ScoreReefL4();
+
+        frc2::CommandPtr DispenseCoralAndMoveBack();
 };
 
 }

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -5,6 +5,7 @@
 #include "subsystems/CoralSubsystem.h"
 #include "subsystems/ElevatorSubsystem.h"
 #include "subsystems/AlgaeSubsystem.h"
+#include "subsystems/CommandSwerveDrivetrain.h"
 
 #include <map>
 #include <tuple>
@@ -13,24 +14,38 @@ namespace subsystems {
 
 class ScoringSuperstructure : public frc2::SubsystemBase {
     public:
-        // @todo This will also need to include the CoralSubsystem and AlgaeSubsystem when they are ready
-        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech);
+        enum ScoringSelector {
+            L1,
+            L2,
+            L3AlgaeAndCoral,
+            L3AlgaeOnly,
+            L4
+        };
 
-        frc2::CommandPtr PrepareElevator(units::inch_t desiredPosition, bool removeAlgae);
+        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech,
+                              CommandSwerveDrivetrain& drivetrain);
+
+        frc2::CommandPtr PrepareScoring(ScoringSelector selectedScore);
+        frc2::CommandPtr PrepareAndScoreIntoReef(ScoringSelector selectedScore);
 
         frc2::CommandPtr ScoreIntoReef();
         frc2::CommandPtr ScoreIntoProcessor();
-        frc2::CommandPtr PrepareAndScoreIntoReef(units::inch_t desiredPosition, bool removeAlgae);
 
         frc2::CommandPtr ToCollectPosition();
         frc2::CommandPtr ToStowPosition();
+
+        frc2::CommandPtr DriveToReefForScoring();
+        frc2::CommandPtr BackUpAfterScoring();
     private:
         ElevatorSubsystem& m_elevator;
         CoralSubsystem& m_coral;
         AlgaeSubsystem& m_algae;
+        CommandSwerveDrivetrain& m_drivetrain;
 
-        units::inch_t m_elevatorSetpointHeight;
-        bool m_collectAlgae;
+        ScoringSelector m_selectedScore = L1;
+
+        static constexpr units::second_t kForwardTimeout = 2_s;
+        static constexpr units::second_t kBackupTimeout = 1_s;
 
         // Values for the tuple are coral and algae angles.
         std::map<units::inch_t, std::tuple<units::degree_t, units::degree_t>> m_elevatorMap = {
@@ -41,6 +56,11 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
             {kElevatorL3Position, std::make_tuple(kCoralL3, kAlgaeStowAngle)},
             {kElevatorL4Position, std::make_tuple(kCoralL4, kAlgaeStowAngle)},
         };
+
+        frc2::CommandPtr ScoreReefL1();
+        frc2::CommandPtr ScoreReefL2();
+        frc2::CommandPtr ScoreReefL3(bool algaeOnly);
+        frc2::CommandPtr ScoreReefL4();
 };
 
 }


### PR DESCRIPTION
Sorry for the large PR! Got a chance to test out the ScoringSuperstructure command changes and had to make some updates to get it working. It ended up being a lot of lines changed, but it was mostly because of the need to repeat the update across all the reef scoring commands. The ScoringSuperstructure changes from https://github.com/bearbotics2358/Smokey-18/pull/54 made these changes very easy! Great job on that!

Related todo items:
 - [x] Update the auto routine commands
 - [ ] Validate `ScoreIntoProcessor` and fix/update as needed
 - [ ] Fix the drive forward/backward distance checks. The distances aren't working, but the timeouts are.
 - [ ] Automatically stow the ScoringSuperstructure after backing up