### PR TITLE
Monday testing and tuning

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -64,9 +64,10 @@ void RobotContainer::ConfigureBindings() {
     m_gamepad.Button(7).OnTrue(frc2::cmd::Parallel(
         frc2::cmd::RunOnce([this] {
             m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Coast);
-        })
+        }),
 
         // @todo Add a command to move the climber to the Ready To Climb position
+        m_climberSubsystem.Extend()
     ));
 
     m_gamepad.Button(11).OnTrue(

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -65,9 +65,12 @@ void RobotContainer::ConfigureBindings() {
         frc2::cmd::RunOnce([this] {
             m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Coast);
         }),
-
-        // @todo Add a command to move the climber to the Ready To Climb position
         m_climberSubsystem.Extend()
+    )).OnFalse(frc2::cmd::Parallel(
+        frc2::cmd::RunOnce([this] {
+            m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Brake);
+        }),
+        m_climberSubsystem.Stow()
     ));
 
     m_gamepad.Button(11).OnTrue(

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -34,6 +34,12 @@ m_scoringSuperstructure(m_elevatorSubsystem, m_coralSubsystem, m_algaeSubsystem,
     AddPathPlannerCommands();
 }
 
+frc2::CommandPtr RobotContainer::AddControllerRumble(double rumble) {
+    return frc2::cmd::RunOnce([this, rumble] {
+        m_joystick.SetRumble(frc::GenericHID::RumbleType::kBothRumble, rumble);
+    });
+}
+
 void RobotContainer::ConfigureBindings() {
     // Note that X is defined as forward according to WPILib convention,
     // and Y is defined as to the left according to WPILib convention.
@@ -54,20 +60,7 @@ void RobotContainer::ConfigureBindings() {
 
     m_drivetrain.RegisterTelemetry([this](auto const &state) { logger.Telemeterize(state); });
 
-    m_joystick.POVRight().WhileTrue(
-        m_drivetrain.ApplyRequest([this]() -> auto&& {
-            return strafe.WithVelocityY(-0.25_mps);
-        })
-    );
-
-    m_joystick.POVLeft().WhileTrue(
-        m_drivetrain.ApplyRequest([this]() -> auto&& {
-            return strafe.WithVelocityY(0.25_mps);
-        })
-    );
-
     // **** Driver Station Buttons **** //
-
     m_gamepad.Button(7).OnTrue(frc2::cmd::Parallel(
         frc2::cmd::RunOnce([this] {
             m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Coast);
@@ -129,14 +122,20 @@ void RobotContainer::ConfigureBindings() {
     ));
 
     // **** Xbox A, B, X, & Y Button functions **** //
-    m_joystick.B().WhileTrue(AlignWithReef(&m_cameraSubsystem, &m_drivetrain).ToPtr());
+    m_joystick.B().WhileTrue(
+        AlignWithReef(&m_cameraSubsystem, &m_drivetrain).ToPtr().AndThen(AddControllerRumble(1.0))
+    ).ToggleOnFalse(
+        AddControllerRumble(0.0)
+    );
 
     m_joystick.X().WhileTrue(m_scoringSuperstructure.ScoreIntoProcessor());
 
     // **** Xbox Trigger & Bumper Buttons **** //
     m_joystick.RightTrigger()
         .OnTrue(
-            m_scoringSuperstructure.ScoreIntoReef()
+            m_scoringSuperstructure.ScoreIntoReef().FinallyDo(
+                [this] { m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::MSG_IDLE); }
+            )
         );
         // .OnFalse(
         //     m_elevatorSubsystem.GoToHeight(m_elevatorSubsystem.CurrentHeight())
@@ -158,6 +157,18 @@ void RobotContainer::ConfigureBindings() {
     m_joystick.POVUp().OnTrue(m_coralSubsystem.dispenseCoral());
 
     m_joystick.POVDown().OnTrue(frc2::cmd::RunOnce([this] { m_drivetrain.SeedFieldCentric(); }));
+
+    m_joystick.POVRight().WhileTrue(
+        m_drivetrain.ApplyRequest([this]() -> auto&& {
+            return strafe.WithVelocityY(-0.25_mps);
+        })
+    );
+
+    m_joystick.POVLeft().WhileTrue(
+        m_drivetrain.ApplyRequest([this]() -> auto&& {
+            return strafe.WithVelocityY(0.25_mps);
+        })
+    );
 }
 
 frc2::Command *RobotContainer::GetAutonomousCommand()

--- a/src/main/cpp/commands/DriveBackAfterScore.cpp
+++ b/src/main/cpp/commands/DriveBackAfterScore.cpp
@@ -15,10 +15,10 @@ void DriveBackAfterScore::Initialize() {
 
 void DriveBackAfterScore::Execute() {
     units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
-    double forward = m_XAlignmentPID.Calculate(m_targetX.value(), currentXDistance.value());
+    double forward = m_XAlignmentPID.Calculate(currentXDistance.value(), m_targetX.value());
     forward = std::clamp(forward, -1.0, 1.0);
 
-    m_drivetrain->SetControl(robotOriented.WithVelocityX(forward * kMaxVelocity));
+    m_drivetrain->SetControl(robotOriented.WithVelocityX(-forward * kMaxVelocity));
 }
 
 bool DriveBackAfterScore::IsFinished() {

--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -18,10 +18,9 @@ void DriveForwardToScore::Initialize() {
 void DriveForwardToScore::Execute() {
     units::inch_t currentXDistance = m_drivetrain->GetState().Pose.X();
     frc::SmartDashboard::PutNumber("Drive Forward Current X", currentXDistance.value());
-    double forward = m_XAlignmentPID.Calculate(m_targetX.value(), currentXDistance.value());
+    double forward = m_XAlignmentPID.Calculate(currentXDistance.value(), m_targetX.value());
     forward = std::clamp(forward, -1.0, 1.0);
-
-    m_drivetrain->SetControl(robotOriented.WithVelocityX(-forward * kMaxVelocity));
+    m_drivetrain->SetControl(robotOriented.WithVelocityX(forward * kMaxVelocity));
 }
 
 bool DriveForwardToScore::IsFinished() {

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -59,7 +59,8 @@ float FeatherCanDecoder::GetAlgaeRawAngleDegrees() {
 }
 
 bool FeatherCanDecoder::IsAlgaeCollected() {
-    return m_algaeCollected;
+    //return m_algaeCollected;
+    return false;
 }
 
 float FeatherCanDecoder::GetClimberAngleDegrees() {

--- a/src/main/cpp/subsystems/Climber.cpp
+++ b/src/main/cpp/subsystems/Climber.cpp
@@ -44,7 +44,9 @@ frc2::CommandPtr Climber::Climb() {
     });
 }
 
-//Cancels the climb
+/**
+ * Prepare the climber by extending it to the Ready To Climb position
+ */
 frc2::CommandPtr Climber::Extend() {
     return frc2::cmd::RunOnce([this] {
         m_setpointAngle = kClimberStartAngle;

--- a/src/main/cpp/subsystems/Climber.cpp
+++ b/src/main/cpp/subsystems/Climber.cpp
@@ -27,12 +27,6 @@ void Climber::Periodic() {
 
     frc::SmartDashboard::PutNumber("Climber Setpoint", m_setpointAngle.value());
 
-    if (CurrentAngle() == 368.500_deg) {
-        frc::SmartDashboard::PutBoolean("Climber Angle Good?", false);
-    } else {
-        frc::SmartDashboard::PutBoolean("Climber Angle Good?", true);
-    }
-
     SetMotorVoltage();
 }
 
@@ -69,7 +63,7 @@ void Climber::SetMotorVoltage() {
     double value = -m_climberPID.Calculate(CurrentAngle(), m_setpointAngle);
     frc::SmartDashboard::PutNumber("Climber PID", value);
 
-    //m_climberMotor.SetVoltage(units::volt_t(value));
+    m_climberMotor.SetVoltage(units::volt_t(value));
 }
 
 //Stops the climb motor completely

--- a/src/main/cpp/subsystems/ElevatorSubsystem.cpp
+++ b/src/main/cpp/subsystems/ElevatorSubsystem.cpp
@@ -37,9 +37,9 @@ void ElevatorSubsystem::Periodic() {
 
     frc::SmartDashboard::PutBoolean("Elevator Limit Switch", IsMagneticLimitSwitchActive());
 
-    // if (IsMagneticLimitSwitchActive()) {
-    //     m_elevatorMotor1.SetPosition(0_tr, 13_ms);
-    // }
+    if (IsLimitSwitchedPressed.Get()) {
+        m_elevatorMotor1.SetPosition(0_tr, 13_ms);
+    }
 
     SetMotorVoltage();
 }

--- a/src/main/cpp/subsystems/ElevatorSubsystem.cpp
+++ b/src/main/cpp/subsystems/ElevatorSubsystem.cpp
@@ -37,9 +37,9 @@ void ElevatorSubsystem::Periodic() {
 
     frc::SmartDashboard::PutBoolean("Elevator Limit Switch", IsMagneticLimitSwitchActive());
 
-    if (IsMagneticLimitSwitchActive()) {
-        m_elevatorMotor1.SetPosition(0_tr, 13_ms);
-    }
+    // if (IsMagneticLimitSwitchActive()) {
+    //     m_elevatorMotor1.SetPosition(0_tr, 13_ms);
+    // }
 
     SetMotorVoltage();
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -83,10 +83,10 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
 }
 
 frc2::CommandPtr ScoringSuperstructure::ScoreReefL4() {
-    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL2Position];
+    auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL4Position];
 
     return frc2::cmd::Parallel(
-        m_elevator.GoToHeight(kElevatorL2Position),
+        m_elevator.GoToHeight(kElevatorL4Position),
         m_coral.GoToAngle(coralAngle),
         DispenseCoralAndMoveBack()
     );

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -68,6 +68,7 @@ public:
 
     frc2::Command *GetAutonomousCommand();
 
+    frc2::CommandPtr AddControllerRumble(double rumble);
 private:
     void ConfigureBindings();
     void AddPathPlannerCommands();

--- a/src/main/include/commands/AlignWithReef.h
+++ b/src/main/include/commands/AlignWithReef.h
@@ -61,7 +61,7 @@ private:
     const units::degree_t kRotationTolerance = 2_deg;
 
     units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
-    units::meter_t kStrafeSetpoint = units::meter_t(-2_in);
+    units::meter_t kStrafeSetpoint = units::meter_t(11_in);
 
     const std::map<int, units::degree_t> kTagAngleMap = {
         {6, 120_deg},

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -26,11 +26,11 @@ private:
     static constexpr double kP = 1.0;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
-    static constexpr units::meters_per_second_t kMaxVelocity = 0.25_mps;
+    static constexpr units::meters_per_second_t kMaxVelocity = 0.5_mps;
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 
-    const units::inch_t kTolerance = 2_in;
-    const units::inch_t kForwardDistance = 4_in;
+    const units::inch_t kTolerance = 1_in;
+    const units::inch_t kForwardDistance = 8_in;
     units::inch_t m_targetX;
 };

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -18,7 +18,7 @@
 constexpr int kClimberMotor1Id = 32;
 
 constexpr units::degree_t kClimberStartAngle = 168.0_deg;
-constexpr units::degree_t kClimberEndAngle = 90.0_deg;
+constexpr units::degree_t kClimberEndAngle = 41.0_deg;
 constexpr units::degree_t kClimberStowAngle = 10.0_deg;
 
 const double kClimberGearRatio = 1.0;
@@ -43,8 +43,8 @@ private:
 
     ctre::phoenix6::hardware::TalonFX m_climberMotor;
 
-    static constexpr units::turns_per_second_t kMaxVelocity = 5_deg_per_s;
-    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 10_deg_per_s_sq;
+    static constexpr units::turns_per_second_t kMaxVelocity = 25_deg_per_s;
+    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 30_deg_per_s_sq;
     static constexpr double kP = 60.0;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -13,7 +13,7 @@ constexpr units::degree_t kCoralStow = 160.0_deg;
 constexpr units::degree_t kCoralL1 = 65.0_deg;
 constexpr units::degree_t kCoralL2 = 55.0_deg;
 constexpr units::degree_t kCoralL3 = 55.0_deg;
-constexpr units::degree_t kCoralL4 = 50.0_deg;
+constexpr units::degree_t kCoralL4 = 47.5_deg;
 
 class CoralSubsystem : public frc2::SubsystemBase {
  public:

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -58,6 +58,11 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
 
         frc2::CommandPtr WaitUntilElevatorAtHeight();
     private:
+
+        frc2::Trigger IsLimitSwitchedPressed = frc2::Trigger([this] {
+            return IsMagneticLimitSwitchActive();
+        });
+
         bool GetElevatorHeightAboveThreshold();
 
         bool elevatorAtHeight = false;

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -44,7 +44,7 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
 
         ScoringSelector m_selectedScore = L1;
 
-        static constexpr units::second_t kForwardTimeout = 2_s;
+        static constexpr units::second_t kForwardTimeout = 2.2_s;
         static constexpr units::second_t kBackupTimeout = 1_s;
 
         // Values for the tuple are coral and algae angles.


### PR DESCRIPTION
These are all the changes the team made for tuning the bot on Monday evening.

* Rumble the controller when done aligning with the AprilTag
* Enable the climber ready/stow switch
* Tune the climber angles and PID
* Fix the positioning bugs in the DriveForward and DriveBackward scoring commands
* Tune the forward/backward scoring sequence
* Disable the algae TOF sensor until the fix can be applied to ignore `0xFFFF` values