### PR TITLE
Ignore algae TOF readings that are invalid

### DIFF
--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -43,8 +43,6 @@ void FeatherCanDecoder::Update() {
     frc::SmartDashboard::PutBoolean("Climber Collected?", m_leftProximity);
 
     UnpackBellyPanCANData();
-    frc::SmartDashboard::PutBoolean("BellyPan Right Proximity?", m_rightBellyPanProximity);
-    frc::SmartDashboard::PutBoolean("BellyPan Left Proximity?", m_leftBellyPanProximity);
 }
 
 float FeatherCanDecoder::GetCoralIntakeAngleDegrees() {
@@ -89,12 +87,12 @@ bool FeatherCanDecoder::IsRightCageHooked() {
     return m_rightProximity;
 }
 
-bool FeatherCanDecoder::IsLeftProximity() {
-    return m_leftBellyPanProximity;
+double FeatherCanDecoder::GetBellyPanLeftDistance() {
+    return m_leftBellyPanDistance;
 }
 
-bool FeatherCanDecoder::IsRightProximity() {
-    return m_rightBellyPanProximity;
+double FeatherCanDecoder::GetBellyPanRightDistance() {
+    return m_rightBellyPanDistance;
 }
 
 void FeatherCanDecoder::UnpackCoralCANData() {
@@ -161,11 +159,21 @@ void FeatherCanDecoder::UnpackBellyPanCANData() {
 
     if (isBellyPanDataValid) {
         int proximityright = (data.data[0] << 8) | data.data[1];
-        frc::SmartDashboard::PutNumber("Is the BellyPan in proximity?", proximityright);
-        m_rightBellyPanProximity = proximityright > kBellyPanProximityThreshold;
+        frc::SmartDashboard::PutNumber("BellyPan Right Distance", proximityright);
+
+        if (IsTOFDataValid(proximityright)) {
+            // Only update the value if the TOF data is good. Otherwise we
+            // may incorrectly report the distance.
+            m_rightBellyPanDistance = proximityright;
+        }
 
         int proximityleft = (data.data[2] << 8) | data.data[3];
-        frc::SmartDashboard::PutNumber("Is the BellyPan in proximity?", proximityleft);
-        m_leftBellyPanProximity = proximityleft > kBellyPanProximityThreshold;
+        frc::SmartDashboard::PutNumber("BellyPan Left Distance", proximityleft);
+
+        if (IsTOFDataValid(proximityleft)) {
+            // Only update the value if the TOF data is good. Otherwise we
+            // may incorrectly report the distance.
+            m_leftBellyPanDistance = proximityleft;
+        }
     }
 }

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -73,6 +73,8 @@ public:
     void UnpackBellyPanCANData();
 
 private:
+    bool IsTOFDataValid(int proximityReading);
+
     float m_coralIntakeAngleDegrees;
     bool m_coralCollected;
     frc::CAN m_coralCAN;

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -33,7 +33,6 @@ public:
     const int kClimberProximityThreshold = 1500;//todo:add the threshold here
 
     const int kBellyPanDeviceID = 4;
-    const int kBellyPanProximityThreshold = 1500;
 
     FeatherCanDecoder();
 
@@ -63,12 +62,12 @@ public:
     void UnpackClimberCANData();
 
     // **** IBellyPanDataProvider interface functions **** //
-    bool m_rightBellyPanProximity;
-    bool m_leftBellyPanProximity;
+    double m_rightBellyPanDistance;
+    double m_leftBellyPanDistance;
     frc::CAN m_bellyPanCAN;
 
-    bool IsLeftProximity() override;
-    bool IsRightProximity() override;
+    double GetBellyPanLeftDistance() override;
+    double GetBellyPanRightDistance() override;
 
     void UnpackBellyPanCANData();
 

--- a/src/main/include/subsystems/IBellyPanDataProvider.h
+++ b/src/main/include/subsystems/IBellyPanDataProvider.h
@@ -2,6 +2,6 @@
 
 class IBellyPanDataProvider {
 public:
-    virtual bool IsRightProximity() = 0;
-    virtual bool IsLeftProximity() = 0;
+    virtual double GetBellyPanRightDistance() = 0;
+    virtual double GetBellyPanLeftDistance() = 0;
 };


### PR DESCRIPTION
The FeatherCAN devices with TOF sensors attached will sometimes send a `0xFFFF` value when they don't have a reading. This is typically very brief and we should avoid using that as the sensor reading when determining if algae is collected.

@saachiKha : Sorry that we ran out of time to work on this together. Here's what I was talking about for ignoring the `0xFFFF` values from the TOF sensor. We can talk through the changes tonight or tomorrow morning to make sure you can get your questions answered about it. One thing that needs to be done that I would appreciate if you could do is find out what a good threshold value is for the algae TOF to determine when we have algae collected.