### PR TITLE
Use the L/R toggle switch to determine which reef pole to align with

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -127,7 +127,15 @@ void RobotContainer::ConfigureBindings() {
 
     // **** Xbox A, B, X, & Y Button functions **** //
     m_joystick.B().WhileTrue(
-        AlignWithReef(&m_cameraSubsystem, &m_drivetrain, false).ToPtr().AndThen(AddControllerRumble(1.0))
+        frc2::cmd::Either(
+            // This checks the state of the L/R reef switch to determine which reef pole to align with
+            // Sending false to AlignWithReef aligns right
+            AlignWithReef(&m_cameraSubsystem, &m_drivetrain, false).ToPtr().AndThen(AddControllerRumble(1.0)),
+            // Sending true to AlignWithReef aligns left
+            AlignWithReef(&m_cameraSubsystem, &m_drivetrain, true).ToPtr().AndThen(AddControllerRumble(1.0)),
+
+            [this] { return m_gamepad.Button(5).Get(); }
+        )
     ).ToggleOnFalse(
         AddControllerRumble(0.0)
     );

--- a/src/main/cpp/commands/AlignWithReef.cpp
+++ b/src/main/cpp/commands/AlignWithReef.cpp
@@ -12,6 +12,12 @@ AlignWithReef::AlignWithReef(CameraSubsystem* camera, subsystems::CommandSwerveD
     AddRequirements(m_drivetrain);
     AddRequirements(m_camera);
 
+    if (goToLeft) {
+        m_strafeSetpoint = kStrafeLeftReefSetpoint;
+    } else {
+        m_strafeSetpoint = kStrafeRightReefSetpoint;
+    }
+
     m_rotationalPID.EnableContinuousInput(-180.0, 180.0);
 }
 
@@ -40,10 +46,10 @@ void AlignWithReef::Execute() {
         forward = 0.0;
     }
 
-    double strafe = m_YAlignmentPID.Calculate(m_camera->getStrafeTransformation().value(), kStrafeSetpoint.value());
+    double strafe = m_YAlignmentPID.Calculate(m_camera->getStrafeTransformation().value(), m_strafeSetpoint.value());
     strafe = std::clamp(strafe, -1.0, 1.0);
 
-    units::meter_t strafe_diff = units::math::abs(kStrafeSetpoint - m_camera->getStrafeTransformation());
+    units::meter_t strafe_diff = units::math::abs(m_strafeSetpoint - m_camera->getStrafeTransformation());
     if (strafe_diff < kStrafeTolerance) {
         strafe = 0.0;
     }
@@ -68,7 +74,7 @@ bool AlignWithReef::IsFinished() {
     }
 
     units::meter_t forward_diff = units::math::abs(kDistanceFromReefSetpoint - m_camera->getForwardTransformation());
-    units::meter_t strafe_diff = units::math::abs(kStrafeSetpoint - m_camera->getStrafeTransformation());
+    units::meter_t strafe_diff = units::math::abs(m_strafeSetpoint - m_camera->getStrafeTransformation());
     units::degree_t currentDegrees = m_drivetrain->GetPose().Rotation().Degrees();
     units::degree_t rotational_diff = units::math::abs(currentDegrees - m_targetDegrees);
 

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -52,7 +52,7 @@ private:
     ElevatorSubsystem m_elevatorSubsystem;
     CoralSubsystem m_coralSubsystem;
     AlgaeSubsystem m_algaeSubsystem;
-    
+
     Climber m_climberSubsystem;
     subsystems::ScoringSuperstructure m_scoringSuperstructure;
 

--- a/src/main/include/commands/AlignWithReef.h
+++ b/src/main/include/commands/AlignWithReef.h
@@ -60,8 +60,10 @@ private:
     const units::meter_t kStrafeTolerance = units::meter_t(0.5_in);
     const units::degree_t kRotationTolerance = 2_deg;
 
-    units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
-    units::meter_t kStrafeSetpoint = units::meter_t(11_in);
+    const units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
+    const units::meter_t kStrafeLeftReefSetpoint = units::meter_t(-2_in);
+    const units::meter_t kStrafeRightReefSetpoint = units::meter_t(kStrafeLeftReefSetpoint + 13_in);
+    units::meter_t m_strafeSetpoint = kStrafeLeftReefSetpoint;
 
     const std::map<int, units::degree_t> kTagAngleMap = {
         {6, 120_deg},


### PR DESCRIPTION
We still need to figure out which switch is the L/R toggle before this can be used.

I forgot to mention this was still a todo item when we were chatting so I went ahead and added what I think will let the operator choose which side of the reef to align with.