### PR TITLE
Automatically stow the superstructure after Coral is collected

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -146,7 +146,10 @@ void RobotContainer::ConfigureBindings() {
         // );
 
     m_joystick.LeftTrigger().OnTrue(
-        m_coralSubsystem.collectCoral()
+        frc2::cmd::Sequence(
+            m_coralSubsystem.collectCoral(),
+            m_scoringSuperstructure.ToStowPosition()
+        )
     );
 
     (m_elevatorSubsystem.IsHeightAboveThreshold || m_joystick.LeftBumper())


### PR DESCRIPTION
This avoids a situation where the drive team may forget to stow everything making it difficult for the camera to see any tags.
