### PR TITLE
Changes from Thursday's practice at the Central Illinois Regional

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -141,6 +141,8 @@ void RobotContainer::ConfigureBindings() {
     );
 
     m_joystick.X().WhileTrue(m_scoringSuperstructure.ScoreIntoProcessor());
+    // m_joystick.X().WhileTrue(m_climberSubsystem.SlowMoveOut());
+    // m_joystick.Y().WhileTrue(m_climberSubsystem.SlowMoveIn());
 
     // **** Xbox Trigger & Bumper Buttons **** //
     m_joystick.RightTrigger()

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -141,8 +141,6 @@ void RobotContainer::ConfigureBindings() {
     );
 
     m_joystick.X().WhileTrue(m_scoringSuperstructure.ScoreIntoProcessor());
-    // m_joystick.X().WhileTrue(m_climberSubsystem.SlowMoveOut());
-    // m_joystick.Y().WhileTrue(m_climberSubsystem.SlowMoveIn());
 
     // **** Xbox Trigger & Bumper Buttons **** //
     m_joystick.RightTrigger()

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -150,17 +150,21 @@ void RobotContainer::ConfigureBindings() {
             m_scoringSuperstructure.ScoreIntoReef().FinallyDo(
                 [this] { m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::MSG_IDLE); }
             )
-        );
-        // .OnFalse(
-        //     m_elevatorSubsystem.GoToHeight(m_elevatorSubsystem.CurrentHeight())
-        // );
-
-    m_joystick.LeftTrigger().OnTrue(
-        frc2::cmd::Sequence(
-            m_coralSubsystem.collectCoral(),
-            m_scoringSuperstructure.ToStowPosition()
         )
-    );
+        .OnFalse(
+            m_scoringSuperstructure.CancelScore()
+        );
+
+    m_joystick.LeftTrigger()
+        .OnTrue(
+            m_coralSubsystem.collectCoral()
+        )
+        .OnFalse(
+            frc2::cmd::Parallel(
+                m_coralSubsystem.StopIntake(),
+                m_scoringSuperstructure.ToStowPosition()
+            )
+        );
 
     (m_elevatorSubsystem.IsHeightAboveThreshold || m_joystick.LeftBumper())
         .OnTrue(

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -46,6 +46,10 @@ float FeatherCanDecoder::GetCoralIntakeRawAngleDegrees() {
     return m_coralIntakeAngleDegrees;
 }
 
+bool FeatherCanDecoder::IsCoralAngleValid() {
+    return m_coralAngleValid;
+}
+
 bool FeatherCanDecoder::IsCoralCollected() {
     return m_coralCollected;
 }
@@ -100,6 +104,8 @@ void FeatherCanDecoder::UnpackCoralCANData() {
         frc::SmartDashboard::PutNumber("Coral Collected Value", proximity);
         m_coralCollected = proximity > kCoralProximityThreshold;
     }
+
+    m_coralAngleValid = isCoralDataValid;
 }
 
 void FeatherCanDecoder::UnpackAlgaeCANData() {

--- a/src/main/cpp/subsystems/AlgaeSubsystem.cpp
+++ b/src/main/cpp/subsystems/AlgaeSubsystem.cpp
@@ -22,7 +22,7 @@ m_algaeDataProvider(dataProvider)
 }
 
 void AlgaeSubsystem::Periodic() {
-    GoToAngle();
+    // GoToAngle();
     frc::SmartDashboard::PutNumber("Algae Angle", CurrentAngle().value());
 }
 

--- a/src/main/cpp/subsystems/Climber.cpp
+++ b/src/main/cpp/subsystems/Climber.cpp
@@ -62,18 +62,6 @@ frc2::CommandPtr Climber::Stow() {
     });
 }
 
-frc2::CommandPtr Climber::SlowMoveOut() {
-    return frc2::cmd::Run([this] {
-        m_climberMotor.SetVoltage(units::volt_t(1.0));
-    });
-}
-
-frc2::CommandPtr Climber::SlowMoveIn() {
-    return frc2::cmd::Run([this] {
-        m_climberMotor.SetVoltage(units::volt_t(-1.0));
-    });
-}
-
 //Sets the motor voltage based on profiled PID calculations
 void Climber::SetMotorVoltage() {
     double value = -m_climberPID.Calculate(CurrentAngle(), m_setpointAngle);

--- a/src/main/cpp/subsystems/Climber.cpp
+++ b/src/main/cpp/subsystems/Climber.cpp
@@ -11,15 +11,17 @@ m_climberDataProvider(dataProvider)
         .WithInverted(true);  //We'll need to tests this
 
     m_climberMotor.GetConfigurator().Apply(motorConfigs);
-    
+
     m_climberMotor.SetPosition(0_tr);
     /*
      * This method blocks the current robot loop until the signal is retrieved or the timeout is activated.
      * The CTRE docs state that this API can ensure that set operations are completed before continuing control flow.
      * This method reports an error to the DriverStation.
      * The link: https://v6.docs.ctr-electronics.com/en/stable/docs/api-reference/api-usage/status-signals.html
-     */ 
+     */
     m_climberMotor.GetPosition().WaitForUpdate(20_ms);
+
+    m_climberPID.EnableContinuousInput(-180.0_deg, 180.0_deg);
 }
 
 void Climber::Periodic() {
@@ -57,6 +59,18 @@ frc2::CommandPtr Climber::Extend() {
 frc2::CommandPtr Climber::Stow() {
     return frc2::cmd::RunOnce([this] {
         m_setpointAngle = kClimberStowAngle;
+    });
+}
+
+frc2::CommandPtr Climber::SlowMoveOut() {
+    return frc2::cmd::Run([this] {
+        m_climberMotor.SetVoltage(units::volt_t(1.0));
+    });
+}
+
+frc2::CommandPtr Climber::SlowMoveIn() {
+    return frc2::cmd::Run([this] {
+        m_climberMotor.SetVoltage(units::volt_t(-1.0));
     });
 }
 

--- a/src/main/cpp/subsystems/CoralSubsystem.cpp
+++ b/src/main/cpp/subsystems/CoralSubsystem.cpp
@@ -24,9 +24,12 @@ void CoralSubsystem::Periodic() {
 
     frc::SmartDashboard::PutNumber("Coral Setpoint", m_setpointAngle);
 
-    double pid_calculation = m_coralPID.Calculate(m_coralDataProvider->GetCoralIntakeAngleDegrees(), m_setpointAngle);
-    frc::SmartDashboard::PutNumber("Coral PID", pid_calculation);
-    SetPivotSpeed(pid_calculation);
+    // Prevent damage if we lose the coral angle
+    if (m_coralDataProvider->IsCoralAngleValid()) {
+        double pid_calculation = m_coralPID.Calculate(m_coralDataProvider->GetCoralIntakeAngleDegrees(), m_setpointAngle);
+        frc::SmartDashboard::PutNumber("Coral PID", pid_calculation);
+        SetPivotSpeed(pid_calculation);
+    }
 }
 
 //Returns true if a coral is collected and false otherwise

--- a/src/main/cpp/subsystems/CoralSubsystem.cpp
+++ b/src/main/cpp/subsystems/CoralSubsystem.cpp
@@ -4,8 +4,8 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 
 CoralSubsystem::CoralSubsystem(ICoralIntakeDataProvider* dataProvider) :
-m_intakeMotor(kCoralIntakeMotorID, rev::spark::SparkMax::MotorType::kBrushless), 
-m_pivotMotor(kCoralPivotMotorID, rev::spark::SparkMax::MotorType::kBrushless), 
+m_intakeMotor(kCoralIntakeMotorID, rev::spark::SparkMax::MotorType::kBrushless),
+m_pivotMotor(kCoralPivotMotorID, rev::spark::SparkMax::MotorType::kBrushless),
 m_coralDataProvider(dataProvider)
 {
     m_setpointAngle = 160.0;
@@ -50,7 +50,7 @@ void CoralSubsystem::SetPivotSpeed(double speed) {
  * Set the desired setpoint angle for the coral scoring mechanism. This function only
  * changes the saved setpoint. The Periodic function is responsible for tracking the
  * setpoint and holding the motor at the angle.
- * 
+ *
  * @param targetAngle The desired angle of the mechanism in degrees
  */
 //Set the angle of the coral scoring mechanism. Requires the desired angle as a parameter
@@ -65,23 +65,23 @@ frc2::CommandPtr CoralSubsystem::collectCoral() {
     return frc2::cmd::StartEnd(
         [this] {
             SetIntakeSpeed(0.5);
-        }, 
+        },
         [this] {
             m_intakeMotor.StopMotor();
-        }, 
+        },
         {this}
     ).WithTimeout(3_s).Until(([this] { return CoralPresent(); })).WithName("collectCoral");
-}   
+}
 
 // Run the intake motor backwards for one second to dispense held coral
 frc2::CommandPtr CoralSubsystem::dispenseCoral() {
     return frc2::cmd::StartEnd(
         [this] {
             SetIntakeSpeed(-0.5);
-        }, 
+        },
         [this] {
             m_intakeMotor.StopMotor();
-        }, 
+        },
         {this}
     ).WithTimeout(1_s).WithName("dispenseCoral");
 }

--- a/src/main/cpp/subsystems/CoralSubsystem.cpp
+++ b/src/main/cpp/subsystems/CoralSubsystem.cpp
@@ -70,7 +70,7 @@ frc2::CommandPtr CoralSubsystem::collectCoral() {
             m_intakeMotor.StopMotor();
         },
         {this}
-    ).WithTimeout(3_s).Until(([this] { return CoralPresent(); })).WithName("collectCoral");
+    ).Until(([this] { return CoralPresent(); })).WithName("collectCoral");
 }
 
 // Run the intake motor backwards for one second to dispense held coral
@@ -84,4 +84,10 @@ frc2::CommandPtr CoralSubsystem::dispenseCoral() {
         },
         {this}
     ).WithTimeout(1_s).WithName("dispenseCoral");
+}
+
+frc2::CommandPtr CoralSubsystem::StopIntake() {
+    return frc2::cmd::RunOnce([this] {
+        m_intakeMotor.StopMotor();
+    });
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -78,14 +78,17 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL3Position),
         m_coral.GoToAngle(coralAngle),
-        frc2::cmd::Either(
-            frc2::cmd::Sequence(
-                m_algae.SetGoalAngle(kAlgaeExtendedAngle),
-                m_algae.Intake()
-            ),
-            m_algae.SetGoalAngle(algaeAngle),
-            [this, algaeOnly] { return algaeOnly; }
-        ),
+
+        // @note Disabling all algae for Friday
+        // frc2::cmd::Either(
+        //     frc2::cmd::Sequence(
+        //         m_algae.SetGoalAngle(kAlgaeExtendedAngle),
+        //         m_algae.Intake()
+        //     ),
+        //     m_algae.SetGoalAngle(algaeAngle),
+        //     [this, algaeOnly] { return algaeOnly; }
+        // ),
+
         DispenseCoralAndMoveBack()
     );
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -34,6 +34,13 @@ frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     );
 }
 
+frc2::CommandPtr ScoringSuperstructure::CancelScore() {
+    return frc2::cmd::Sequence(
+        // DriveBackAfterScore(&m_drivetrain).WithTimeout(1_s),
+        ToStowPosition()
+    );
+}
+
 frc2::CommandPtr ScoringSuperstructure::ScoreIntoReef() {
     return frc2::cmd::Select<ScoringSelector>([this] {
             return m_selectedScore;
@@ -60,8 +67,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL2() {
 
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL2Position),
-        m_coral.GoToAngle(coralAngle),
-        DispenseCoralAndMoveBack()
+        m_coral.GoToAngle(coralAngle)
+        // DispenseCoralAndMoveBack()
     );
 }
 
@@ -78,8 +85,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
             ),
             m_algae.SetGoalAngle(algaeAngle),
             [this, algaeOnly] { return algaeOnly; }
-        ),
-        DispenseCoralAndMoveBack()
+        )
+        // DispenseCoralAndMoveBack()
     );
 }
 
@@ -88,8 +95,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL4() {
 
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL4Position),
-        m_coral.GoToAngle(coralAngle),
-        DispenseCoralAndMoveBack()
+        m_coral.GoToAngle(coralAngle)
+        // DispenseCoralAndMoveBack()
     );
 }
 

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -36,7 +36,7 @@ frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
 
 frc2::CommandPtr ScoringSuperstructure::CancelScore() {
     return frc2::cmd::Sequence(
-        // DriveBackAfterScore(&m_drivetrain).WithTimeout(1_s),
+        DriveBackAfterScore(&m_drivetrain).WithTimeout(1_s),
         ToStowPosition()
     );
 }
@@ -67,8 +67,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL2() {
 
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL2Position),
-        m_coral.GoToAngle(coralAngle)
-        // DispenseCoralAndMoveBack()
+        m_coral.GoToAngle(coralAngle),
+        DispenseCoralAndMoveBack()
     );
 }
 
@@ -85,8 +85,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
             ),
             m_algae.SetGoalAngle(algaeAngle),
             [this, algaeOnly] { return algaeOnly; }
-        )
-        // DispenseCoralAndMoveBack()
+        ),
+        DispenseCoralAndMoveBack()
     );
 }
 
@@ -95,8 +95,8 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL4() {
 
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL4Position),
-        m_coral.GoToAngle(coralAngle)
-        // DispenseCoralAndMoveBack()
+        m_coral.GoToAngle(coralAngle),
+        DispenseCoralAndMoveBack()
     );
 }
 

--- a/src/main/deploy/pathplanner/autos/Auto-Bottom-22-Return.auto
+++ b/src/main/deploy/pathplanner/autos/Auto-Bottom-22-Return.auto
@@ -11,9 +11,9 @@
           }
         },
         {
-          "type": "wait",
+          "type": "named",
           "data": {
-            "waitTime": 5.0
+            "name": "ScoreL4"
           }
         },
         {

--- a/src/main/deploy/pathplanner/autos/Auto-Middle-21-Return.auto
+++ b/src/main/deploy/pathplanner/autos/Auto-Middle-21-Return.auto
@@ -11,15 +11,9 @@
           }
         },
         {
-          "type": "wait",
+          "type": "named",
           "data": {
-            "waitTime": 5.0
-          }
-        },
-        {
-          "type": "path",
-          "data": {
-            "pathName": "21-GetOutOfWay"
+            "name": "ScoreL4"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/Auto-Top-20-Return.auto
+++ b/src/main/deploy/pathplanner/autos/Auto-Top-20-Return.auto
@@ -11,9 +11,9 @@
           }
         },
         {
-          "type": "wait",
+          "type": "named",
           "data": {
-            "waitTime": 5.0
+            "name": "ScoreL4"
           }
         },
         {

--- a/src/main/include/commands/AlignWithReef.h
+++ b/src/main/include/commands/AlignWithReef.h
@@ -61,7 +61,7 @@ private:
     const units::degree_t kRotationTolerance = 2_deg;
 
     const units::meter_t kDistanceFromReefSetpoint = units::meter_t(30_in);
-    const units::meter_t kStrafeLeftReefSetpoint = units::meter_t(-2_in);
+    const units::meter_t kStrafeLeftReefSetpoint = units::meter_t(2_in);
     const units::meter_t kStrafeRightReefSetpoint = units::meter_t(kStrafeLeftReefSetpoint + 13_in);
     units::meter_t m_strafeSetpoint = kStrafeLeftReefSetpoint;
 

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -30,6 +30,7 @@ public:
     const int kClimberDeviceID = 3;
     const int kClimberAPIId = 3;
     const double kClimberAngleOffsetDegrees = -368.5;
+    // const double kClimberAngleOffsetDegrees = 0.0;
     const int kClimberProximityThreshold = 1500;//todo:add the threshold here
 
     const int kBellyPanDeviceID = 4;

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -43,6 +43,7 @@ public:
     // **** ICoralIntakeDataProvider interface functions **** //
     float GetCoralIntakeAngleDegrees() override;
     float GetCoralIntakeRawAngleDegrees() override;
+    bool IsCoralAngleValid() override;
     bool IsCoralCollected() override;
 
     // **** IAlgaeDataProvider interface functions **** //
@@ -75,6 +76,7 @@ public:
 
 private:
     float m_coralIntakeAngleDegrees;
+    bool m_coralAngleValid;
     bool m_coralCollected;
     frc::CAN m_coralCAN;
 

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -36,9 +36,6 @@ public:
 
     frc2::CommandPtr StopClimber();
 
-    frc2::CommandPtr SlowMoveOut();
-    frc2::CommandPtr SlowMoveIn();
-
 private:
     void SetMotorVoltage();
 

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -46,7 +46,7 @@ private:
 
     ctre::phoenix6::hardware::TalonFX m_climberMotor;
 
-    static constexpr units::turns_per_second_t kMaxVelocity = 80_deg_per_s;
+    static constexpr units::turns_per_second_t kMaxVelocity = 60_deg_per_s;
     static constexpr units::turns_per_second_squared_t kMaxAcceleration = 80_deg_per_s_sq;
     static constexpr double kP = 65.0;
     static constexpr double kI = 0.0;

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -18,7 +18,7 @@
 constexpr int kClimberMotor1Id = 32;
 
 constexpr units::degree_t kClimberStartAngle = 165.0_deg;
-constexpr units::degree_t kClimberEndAngle = 41.0_deg;
+constexpr units::degree_t kClimberEndAngle = 46.0_deg;
 constexpr units::degree_t kClimberStowAngle = 15.0_deg;
 
 const double kClimberGearRatio = 1.0;
@@ -46,9 +46,9 @@ private:
 
     ctre::phoenix6::hardware::TalonFX m_climberMotor;
 
-    static constexpr units::turns_per_second_t kMaxVelocity = 35_deg_per_s;
-    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 40_deg_per_s_sq;
-    static constexpr double kP = 60.0;
+    static constexpr units::turns_per_second_t kMaxVelocity = 80_deg_per_s;
+    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 80_deg_per_s_sq;
+    static constexpr double kP = 65.0;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
 

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -17,7 +17,7 @@
 
 constexpr int kClimberMotor1Id = 32;
 
-constexpr units::degree_t kClimberStartAngle = 160.0_deg;
+constexpr units::degree_t kClimberStartAngle = 165.0_deg;
 constexpr units::degree_t kClimberEndAngle = 41.0_deg;
 constexpr units::degree_t kClimberStowAngle = 15.0_deg;
 

--- a/src/main/include/subsystems/Climber.h
+++ b/src/main/include/subsystems/Climber.h
@@ -17,9 +17,9 @@
 
 constexpr int kClimberMotor1Id = 32;
 
-constexpr units::degree_t kClimberStartAngle = 168.0_deg;
+constexpr units::degree_t kClimberStartAngle = 160.0_deg;
 constexpr units::degree_t kClimberEndAngle = 41.0_deg;
-constexpr units::degree_t kClimberStowAngle = 10.0_deg;
+constexpr units::degree_t kClimberStowAngle = 15.0_deg;
 
 const double kClimberGearRatio = 1.0;
 
@@ -36,6 +36,9 @@ public:
 
     frc2::CommandPtr StopClimber();
 
+    frc2::CommandPtr SlowMoveOut();
+    frc2::CommandPtr SlowMoveIn();
+
 private:
     void SetMotorVoltage();
 
@@ -43,8 +46,8 @@ private:
 
     ctre::phoenix6::hardware::TalonFX m_climberMotor;
 
-    static constexpr units::turns_per_second_t kMaxVelocity = 25_deg_per_s;
-    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 30_deg_per_s_sq;
+    static constexpr units::turns_per_second_t kMaxVelocity = 35_deg_per_s;
+    static constexpr units::turns_per_second_squared_t kMaxAcceleration = 40_deg_per_s_sq;
     static constexpr double kP = 60.0;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -32,6 +32,12 @@ class CoralSubsystem : public frc2::SubsystemBase {
   frc2::CommandPtr StopIntake();
 
  private:
+    // Per the REV documentation, the Neo 550 has 42 counts per revolution
+    static constexpr double kNeoCountsPerRev = 42;
+
+    // @todo Get the correct gear ratio
+    static constexpr double kCoralPivotGearRatio = 125.0;
+
     const int kPivotMotorMaxCurrentAmps = 10;
     const int ANGLE_TOLERANCE = 3.0;
     const int kCoralPivotMotorID = 58;
@@ -45,8 +51,12 @@ class CoralSubsystem : public frc2::SubsystemBase {
 
     rev::spark::SparkMax m_intakeMotor;
     rev::spark::SparkMax m_pivotMotor;
+    rev::spark::SparkRelativeEncoder m_pivotEncoder;
+    double m_relEncoderOffsetDegrees = 0.0;
 
     ICoralIntakeDataProvider* m_coralDataProvider;
 
     frc::PIDController m_coralPID{kCoralP, kCoralI, kCoralD};
+
+    units::degree_t GetAngleDegreesFallback();
 };

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -13,7 +13,7 @@ constexpr units::degree_t kCoralStow = 160.0_deg;
 constexpr units::degree_t kCoralL1 = 65.0_deg;
 constexpr units::degree_t kCoralL2 = 55.0_deg;
 constexpr units::degree_t kCoralL3 = 55.0_deg;
-constexpr units::degree_t kCoralL4 = 45.5_deg;
+constexpr units::degree_t kCoralL4 = 30_deg;
 
 class CoralSubsystem : public frc2::SubsystemBase {
  public:
@@ -29,6 +29,7 @@ class CoralSubsystem : public frc2::SubsystemBase {
   frc2::CommandPtr GoToAngle(units::degree_t angle);
   frc2::CommandPtr collectCoral();
   frc2::CommandPtr dispenseCoral();
+  frc2::CommandPtr StopIntake();
 
  private:
     const int kPivotMotorMaxCurrentAmps = 10;

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -8,12 +8,12 @@
 #include <frc/controller/PIDController.h>
 #include "subsystems/ICoralIntakeDataProvider.h"
 
-constexpr units::degree_t kCoralCollect = 150.0_deg;
+constexpr units::degree_t kCoralCollect = 145.0_deg;
 constexpr units::degree_t kCoralStow = 160.0_deg;
 constexpr units::degree_t kCoralL1 = 65.0_deg;
 constexpr units::degree_t kCoralL2 = 55.0_deg;
 constexpr units::degree_t kCoralL3 = 55.0_deg;
-constexpr units::degree_t kCoralL4 = 47.5_deg;
+constexpr units::degree_t kCoralL4 = 45.5_deg;
 
 class CoralSubsystem : public frc2::SubsystemBase {
  public:

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -27,7 +27,7 @@ constexpr units::inch_t kElevatorProcessorPosition = 10_in;
 constexpr units::inch_t kElevatorL1Position = 0_in;
 constexpr units::inch_t kElevatorL2Position = 12_in;
 constexpr units::inch_t kElevatorL3Position = 28_in;
-constexpr units::inch_t kElevatorL4Position = 57_in;
+constexpr units::inch_t kElevatorL4Position = 61.5_in;
 
 constexpr float kSlowElevator = 0.6;
 

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -21,7 +21,7 @@ constexpr int kElevatorMotor2Id = 37;
 constexpr int kLimitSwitchId = 0;
 
 // @todo Assign these to real values when we know the distances
-constexpr units::inch_t kElevatorCollectPosition = 3.0_in;
+constexpr units::inch_t kElevatorCollectPosition = 1.5_in;
 constexpr units::inch_t kElevatorStowPosition = 0_in;
 constexpr units::inch_t kElevatorProcessorPosition = 10_in;
 constexpr units::inch_t kElevatorL1Position = 0_in;
@@ -58,7 +58,7 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
 
         frc2::CommandPtr WaitUntilElevatorAtHeight();
     private:
-    
+
         bool GetElevatorHeightAboveThreshold();
 
         bool elevatorAtHeight = false;

--- a/src/main/include/subsystems/ICoralIntakeDataProvider.h
+++ b/src/main/include/subsystems/ICoralIntakeDataProvider.h
@@ -8,6 +8,8 @@ public:
     // Provide the raw angle of the coral mechanism. Does not include any offsets.
     virtual float GetCoralIntakeRawAngleDegrees() = 0;
 
+    virtual bool IsCoralAngleValid() = 0;
+
     // Return a simple boolean to indicate whether a piece of coral has been collected
     virtual bool IsCoralCollected() = 0;
 };

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -36,6 +36,8 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
 
         frc2::CommandPtr DriveToReefForScoring();
         frc2::CommandPtr BackUpAfterScoring();
+
+        frc2::CommandPtr CancelScore();
     private:
         ElevatorSubsystem& m_elevator;
         CoralSubsystem& m_coral;


### PR DESCRIPTION
These are all the changes we made throughout the day today. I'll tag the code that we used for the last practice match along with the code that we had after climber testing at the end of the day. The remaining changes are from changes made this evening to incorporate the relative encoder position from the coral pivot motor as a fallback for if the FeatherCAN loses power.