### PR TITLE
Enable commands in autonomous

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -22,16 +22,18 @@ m_algaeSubsystem(m_featherCanDecoder),
 m_climberSubsystem(m_featherCanDecoder),
 m_scoringSuperstructure(m_elevatorSubsystem, m_coralSubsystem, m_algaeSubsystem, m_drivetrain)
 {
-    m_autoChooser = pathplanner::AutoBuilder::buildAutoChooser("Tests");
-    frc::SmartDashboard::PutData("Auto Mode", &m_autoChooser);
-
     m_LED.SetLEDState(ArduinoConstants::RIO_MESSAGES::MSG_IDLE);
 
     m_drivetrain.ConfigNeutralMode(ctre::phoenix6::signals::NeutralModeValue::Brake);
 
-    ConfigureBindings();
-
     AddPathPlannerCommands();
+
+    m_drivetrain.ConfigureAutoBuilder();
+
+    m_autoChooser = pathplanner::AutoBuilder::buildAutoChooser("Tests");
+    frc::SmartDashboard::PutData("Auto Mode", &m_autoChooser);
+
+    ConfigureBindings();
 }
 
 frc2::CommandPtr RobotContainer::AddControllerRumble(double rumble) {

--- a/src/main/include/subsystems/CommandSwerveDrivetrain.h
+++ b/src/main/include/subsystems/CommandSwerveDrivetrain.h
@@ -128,7 +128,6 @@ public:
         if (utils::IsSimulation()) {
             StartSimThread();
         }
-        ConfigureAutoBuilder();
     }
 
     /**
@@ -155,7 +154,6 @@ public:
         if (utils::IsSimulation()) {
             StartSimThread();
         }
-        ConfigureAutoBuilder();
     }
 
     /**
@@ -189,7 +187,6 @@ public:
         if (utils::IsSimulation()) {
             StartSimThread();
         }
-        ConfigureAutoBuilder();
     }
 
     /**
@@ -255,8 +252,8 @@ public:
     }
 
     frc::Pose2d GetPose();
-private:
     void ConfigureAutoBuilder();
+private:
     void StartSimThread();
 };
 


### PR DESCRIPTION
Worked with @VG-Fish to find a simpler solution to getting the commands functioning for autonomous routines.

The main change to get this to work was to ensure that `AddPathPlannerCommands()` was called before the autobuilder was configured and also before the button bindings were set.