### PR TITLE
Drive forward fix

### DIFF
--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -6,10 +6,6 @@
 
 #include <frc/smartdashboard/SmartDashboard.h>
 
-#include <chrono>
-
-using namespace std::chrono;
-
 DriveForwardToScore::DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance)
     : m_drivetrain{drivetrain}, 
     m_forwardDistance{distance} {
@@ -17,13 +13,7 @@ DriveForwardToScore::DriveForwardToScore(subsystems::CommandSwerveDrivetrain* dr
 }
 
 void DriveForwardToScore::Initialize() {
-    m_startTime = steady_clock::now();
-
-    m_initialPose = frc::Pose2d(m_drivetrain->GetPose());
-
-    if (m_forwardDistance == 0_in) {
-        m_forwardDistance = kDefaultDistance;
-    }
+    m_initialPose = m_drivetrain->GetPose();
 }
 
 void DriveForwardToScore::Execute() {
@@ -35,13 +25,6 @@ void DriveForwardToScore::Execute() {
 }
 
 bool DriveForwardToScore::IsFinished() {
-    //auto endTime = steady_clock::now();
-    //auto timeDiff = duration_cast<duration<double>>(endTime - m_startTime);
-
-    // if (timeDiff.count() > 1.5) {
-    //     return true;
-    // }
-
     units::inch_t currentDistanceTraveled = units::inch_t(m_initialPose.Translation().Distance(m_drivetrain->GetPose().Translation()));
     return units::math::abs(currentDistanceTraveled - m_forwardDistance) < kTolerance;
 }

--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -20,6 +20,10 @@ void DriveForwardToScore::Initialize() {
     m_startTime = steady_clock::now();
 
     m_initialPose = frc::Pose2d(m_drivetrain->GetPose());
+
+    if (m_forwardDistance == 0_in) {
+        m_forwardDistance = kDefaultDistance;
+    }
 }
 
 void DriveForwardToScore::Execute() {

--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -17,7 +17,7 @@ void DriveForwardToScore::Initialize() {
 }
 
 void DriveForwardToScore::Execute() {
-    units::inch_t currentDistanceTraveled = units::inch_t(m_initialPose.Translation().Distance(m_drivetrain->GetPose().Translation()));
+    units::inch_t currentDistanceTraveled = GetDistance(m_initialPose, m_drivetrain->GetPose());
     frc::SmartDashboard::PutNumber("Drive Forward Current X", currentDistanceTraveled.value());
     double forward = m_XAlignmentPID.Calculate(currentDistanceTraveled.value(), m_forwardDistance.value());
     forward = std::clamp(forward, -1.0, 1.0);
@@ -27,4 +27,8 @@ void DriveForwardToScore::Execute() {
 bool DriveForwardToScore::IsFinished() {
     units::inch_t currentDistanceTraveled = units::inch_t(m_initialPose.Translation().Distance(m_drivetrain->GetPose().Translation()));
     return units::math::abs(currentDistanceTraveled - m_forwardDistance) < kTolerance;
+}
+
+units::inch_t DriveForwardToScore::GetDistance(frc::Pose2d first, frc::Pose2d second) {
+    return units::inch_t(first.Translation().Distance(second.Translation()));
 }

--- a/src/main/cpp/commands/DriveForwardToScore.cpp
+++ b/src/main/cpp/commands/DriveForwardToScore.cpp
@@ -10,33 +10,34 @@
 
 using namespace std::chrono;
 
-DriveForwardToScore::DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain)
-    : m_drivetrain{drivetrain} {
+DriveForwardToScore::DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance)
+    : m_drivetrain{drivetrain}, 
+    m_forwardDistance{distance} {
     AddRequirements(m_drivetrain);
 }
 
 void DriveForwardToScore::Initialize() {
     m_startTime = steady_clock::now();
 
-    m_targetX = kForwardDistance + m_drivetrain->GetPose().X();
+    m_initialPose = frc::Pose2d(m_drivetrain->GetPose());
 }
 
 void DriveForwardToScore::Execute() {
-    units::inch_t currentXDistance = m_drivetrain->GetPose().X();
-    frc::SmartDashboard::PutNumber("Drive Forward Current X", currentXDistance.value());
-    double forward = m_XAlignmentPID.Calculate(currentXDistance.value(), m_targetX.value());
+    units::inch_t currentDistanceTraveled = units::inch_t(m_initialPose.Translation().Distance(m_drivetrain->GetPose().Translation()));
+    frc::SmartDashboard::PutNumber("Drive Forward Current X", currentDistanceTraveled.value());
+    double forward = m_XAlignmentPID.Calculate(currentDistanceTraveled.value(), m_forwardDistance.value());
     forward = std::clamp(forward, -1.0, 1.0);
     m_drivetrain->SetControl(robotOriented.WithVelocityX(forward * kMaxVelocity));
 }
 
 bool DriveForwardToScore::IsFinished() {
-    auto endTime = steady_clock::now();
-    auto timeDiff = duration_cast<duration<double>>(endTime - m_startTime);
+    //auto endTime = steady_clock::now();
+    //auto timeDiff = duration_cast<duration<double>>(endTime - m_startTime);
 
     // if (timeDiff.count() > 1.5) {
     //     return true;
     // }
 
-    units::inch_t currentXDistance = m_drivetrain->GetPose().X();
-    return units::math::abs(currentXDistance - m_targetX) < kTolerance;
+    units::inch_t currentDistanceTraveled = units::inch_t(m_initialPose.Translation().Distance(m_drivetrain->GetPose().Translation()));
+    return units::math::abs(currentDistanceTraveled - m_forwardDistance) < kTolerance;
 }

--- a/src/main/cpp/subsystems/CameraSubsystem.cpp
+++ b/src/main/cpp/subsystems/CameraSubsystem.cpp
@@ -26,6 +26,7 @@ void CameraSubsystem::updateData() {
         frc::SmartDashboard::PutNumber("Rotation", bestTarget.GetYaw());
         frc::SmartDashboard::PutNumber("Strafe Distance", units::inch_t(getStrafeTransformation()).value());
         frc::SmartDashboard::PutNumber("Forward Distance", units::inch_t(getForwardTransformation()).value());
+        frc::SmartDashboard::PutNumber("Distance", units::inch_t(getDistance()).value());
     } else {
         frc::SmartDashboard::PutBoolean("Has Targets", false);
     }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -10,13 +10,11 @@ ScoringSuperstructure::ScoringSuperstructure(
     ElevatorSubsystem& elevator,
     CoralSubsystem& coralMech,
     AlgaeSubsystem& algaeMech,
-    CameraSubsystem& camera,
     CommandSwerveDrivetrain& drivetrain
 ):
 m_elevator(elevator),
 m_coral(coralMech),
 m_algae(algaeMech),
-m_camera(camera),
 m_drivetrain(drivetrain)
 {}
 
@@ -29,7 +27,7 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
-        DriveForwardToScore(&m_drivetrain, units::inch_t(m_camera.getDistance())).WithTimeout(2.0_s),
+        DriveForwardToScore(&m_drivetrain, 12_in).WithTimeout(2.0_s),
         frc2::cmd::RunOnce([this] {m_drivetrain.SetControl(stopDriving);}),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -27,7 +27,7 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
-        DriveForwardToScore(&m_drivetrain, 12_in).WithTimeout(2.0_s),
+        DriveForwardToScore(&m_drivetrain, kForwardDistance).WithTimeout(2.0_s),
         frc2::cmd::RunOnce([this] {m_drivetrain.SetControl(stopDriving);}),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -27,7 +27,8 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
-        DriveForwardToScore(&m_drivetrain).WithTimeout(1.0_s),
+        DriveForwardToScore(&m_drivetrain, 12_in).WithTimeout(2.0_s),
+        frc2::cmd::RunOnce([this] {m_drivetrain.SetControl(stopDriving);}),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),
         ToStowPosition()

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -28,10 +28,16 @@ frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
         DriveForwardToScore(&m_drivetrain, kForwardDistance).WithTimeout(2.0_s),
-        frc2::cmd::RunOnce([this] {m_drivetrain.SetControl(stopDriving);}),
+        StopDriving(),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),
         ToStowPosition()
+    );
+}
+
+frc2::CommandPtr ScoringSuperstructure::StopDriving() {
+    return frc2::cmd::RunOnce(
+        [this] {m_drivetrain.SetControl(stopDriving);}  
     );
 }
 

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -27,7 +27,7 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
-        DriveForwardToScore(&m_drivetrain, kForwardDistance).WithTimeout(2.0_s),
+        DriveForwardToScore(&m_drivetrain).WithTimeout(2.0_s),
         StopDriving(),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -10,11 +10,13 @@ ScoringSuperstructure::ScoringSuperstructure(
     ElevatorSubsystem& elevator,
     CoralSubsystem& coralMech,
     AlgaeSubsystem& algaeMech,
+    CameraSubsystem& camera,
     CommandSwerveDrivetrain& drivetrain
 ):
 m_elevator(elevator),
 m_coral(coralMech),
 m_algae(algaeMech),
+m_camera(camera),
 m_drivetrain(drivetrain)
 {}
 
@@ -27,7 +29,7 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
         m_elevator.WaitUntilElevatorAtHeight(),
-        DriveForwardToScore(&m_drivetrain, 12_in).WithTimeout(2.0_s),
+        DriveForwardToScore(&m_drivetrain, units::inch_t(m_camera.getDistance())).WithTimeout(2.0_s),
         frc2::cmd::RunOnce([this] {m_drivetrain.SetControl(stopDriving);}),
         m_coral.dispenseCoral(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -31,9 +31,10 @@ private:
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 
     const units::inch_t kTolerance = 0.5_in;
-    units::inch_t m_forwardDistance = 12_in;
-    units::inch_t m_targetX;
+    units::inch_t m_forwardDistance;
     frc::Pose2d m_initialPose;
+
+    const units::inch_t kDefaultDistance = 12_in;
 
     std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
 };

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -10,10 +10,13 @@
 class DriveForwardToScore
     : public frc2::CommandHelper<frc2::Command, DriveForwardToScore> {
 public:
-    explicit DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance);
+    static constexpr units::inch_t kDefaultDistance = 8_in;
+
+    explicit DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance = kDefaultDistance);
     void Initialize() override;
     void Execute() override;
     bool IsFinished() override;
+    units::inch_t GetDistance(frc::Pose2d first, frc::Pose2d second);
 
     swerve::requests::RobotCentric robotOriented = swerve::requests::RobotCentric{}
         .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
@@ -33,6 +36,4 @@ private:
     const units::inch_t kTolerance = 1_in;
     units::inch_t m_forwardDistance;
     frc::Pose2d m_initialPose;
-
-    std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
 };

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -34,7 +34,5 @@ private:
     units::inch_t m_forwardDistance;
     frc::Pose2d m_initialPose;
 
-    const units::inch_t kDefaultDistance = 7_in;
-
     std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
 };

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -10,7 +10,7 @@
 class DriveForwardToScore
     : public frc2::CommandHelper<frc2::Command, DriveForwardToScore> {
 public:
-    explicit DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain);
+    explicit DriveForwardToScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance);
     void Initialize() override;
     void Execute() override;
     bool IsFinished() override;
@@ -30,9 +30,10 @@ private:
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 
-    const units::inch_t kTolerance = 1_in;
-    const units::inch_t kForwardDistance = 7_in;
+    const units::inch_t kTolerance = 0.5_in;
+    units::inch_t m_forwardDistance = 12_in;
     units::inch_t m_targetX;
+    frc::Pose2d m_initialPose;
 
     std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
 };

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -30,11 +30,11 @@ private:
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 
-    const units::inch_t kTolerance = 0.5_in;
+    const units::inch_t kTolerance = 1_in;
     units::inch_t m_forwardDistance;
     frc::Pose2d m_initialPose;
 
-    const units::inch_t kDefaultDistance = 12_in;
+    const units::inch_t kDefaultDistance = 7_in;
 
     std::chrono::steady_clock::time_point m_startTime = std::chrono::steady_clock::now();
 };

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -49,6 +49,12 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         static constexpr units::second_t kForwardTimeout = 0.5_s;
         static constexpr units::second_t kBackupTimeout = 1_s;
 
+        swerve::requests::RobotCentric stopDriving = swerve::requests::RobotCentric{}
+            .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
+            .WithVelocityX(0_mps)
+            .WithVelocityY(0_mps)
+            .WithRotationalRate(0_rad_per_s);
+
         // Values for the tuple are coral and algae angles.
         std::map<units::inch_t, std::tuple<units::degree_t, units::degree_t>> m_elevatorMap = {
             {kElevatorStowPosition, std::make_tuple(kCoralStow, kAlgaeStowAngle)},

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -5,6 +5,7 @@
 #include "subsystems/CoralSubsystem.h"
 #include "subsystems/ElevatorSubsystem.h"
 #include "subsystems/AlgaeSubsystem.h"
+#include "subsystems/CameraSubsystem.h"
 #include "subsystems/CommandSwerveDrivetrain.h"
 
 #include <map>
@@ -22,7 +23,7 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
             L4
         };
 
-        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech,
+        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech, CameraSubsystem& camera, 
                               CommandSwerveDrivetrain& drivetrain);
 
         frc2::CommandPtr PrepareScoring(ScoringSelector selectedScore);
@@ -42,6 +43,7 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         ElevatorSubsystem& m_elevator;
         CoralSubsystem& m_coral;
         AlgaeSubsystem& m_algae;
+        CameraSubsystem& m_camera;
         CommandSwerveDrivetrain& m_drivetrain;
 
         ScoringSelector m_selectedScore = L1;

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -36,6 +36,7 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
 
         frc2::CommandPtr DriveToReefForScoring();
         frc2::CommandPtr BackUpAfterScoring();
+        frc2::CommandPtr StopDriving();
 
         frc2::CommandPtr CancelScore();
     private:

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -5,7 +5,6 @@
 #include "subsystems/CoralSubsystem.h"
 #include "subsystems/ElevatorSubsystem.h"
 #include "subsystems/AlgaeSubsystem.h"
-#include "subsystems/CameraSubsystem.h"
 #include "subsystems/CommandSwerveDrivetrain.h"
 
 #include <map>
@@ -23,7 +22,7 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
             L4
         };
 
-        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech, CameraSubsystem& camera, 
+        ScoringSuperstructure(ElevatorSubsystem& elevator, CoralSubsystem& coralMech, AlgaeSubsystem& algaeMech, 
                               CommandSwerveDrivetrain& drivetrain);
 
         frc2::CommandPtr PrepareScoring(ScoringSelector selectedScore);
@@ -43,7 +42,6 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         ElevatorSubsystem& m_elevator;
         CoralSubsystem& m_coral;
         AlgaeSubsystem& m_algae;
-        CameraSubsystem& m_camera;
         CommandSwerveDrivetrain& m_drivetrain;
 
         ScoringSelector m_selectedScore = L1;

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -49,6 +49,8 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         static constexpr units::second_t kForwardTimeout = 0.5_s;
         static constexpr units::second_t kBackupTimeout = 1_s;
 
+        static constexpr units::inch_t kForwardDistance = 8_in;
+
         swerve::requests::RobotCentric stopDriving = swerve::requests::RobotCentric{}
             .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
             .WithVelocityX(0_mps)

--- a/src/main/include/subsystems/ScoringSuperstructure.h
+++ b/src/main/include/subsystems/ScoringSuperstructure.h
@@ -50,8 +50,6 @@ class ScoringSuperstructure : public frc2::SubsystemBase {
         static constexpr units::second_t kForwardTimeout = 0.5_s;
         static constexpr units::second_t kBackupTimeout = 1_s;
 
-        static constexpr units::inch_t kForwardDistance = 8_in;
-
         swerve::requests::RobotCentric stopDriving = swerve::requests::RobotCentric{}
             .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
             .WithVelocityX(0_mps)


### PR DESCRIPTION
The drive forward to score command now drives the correct distance regardless of where the robot is on the field.