### PR TITLE
Sunday improvements

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -84,7 +84,15 @@ void RobotContainer::ConfigureBindings() {
         AddControllerRumble(frc::GenericHID::RumbleType::kBothRumble, 0.0)
     );
 
-    m_driverJoystick.X().WhileTrue(m_scoringSuperstructure.ScoreIntoProcessor());
+    m_driverJoystick.X().OnTrue(
+        // @todo Move these controls to the ScoringSuperstructure
+        frc2::cmd::Parallel(
+            m_elevatorSubsystem.GoToHeight(kElevatorAlgaeOnlyL3Position),
+            m_algaeSubsystem.SetGoalAngle(kAlgaeExtendedAngle).AndThen(m_algaeSubsystem.Dispense())
+        )
+    ).OnFalse(
+        m_scoringSuperstructure.ToStowPosition()
+    );
 
     // **** Xbox Trigger & Bumper Buttons **** //
     m_driverJoystick.RightTrigger()

--- a/src/main/cpp/commands/DriveBackAfterScore.cpp
+++ b/src/main/cpp/commands/DriveBackAfterScore.cpp
@@ -7,7 +7,7 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 
 DriveBackAfterScore::DriveBackAfterScore(subsystems::CommandSwerveDrivetrain* drivetrain, units::inch_t distance)
-    : m_drivetrain{drivetrain}, 
+    : m_drivetrain{drivetrain},
     m_backwardDistance{distance} {
     AddRequirements(m_drivetrain);
 }

--- a/src/main/cpp/io/FeatherCanDecoder.cpp
+++ b/src/main/cpp/io/FeatherCanDecoder.cpp
@@ -62,7 +62,7 @@ bool FeatherCanDecoder::IsCoralCollected() {
 }
 
 float FeatherCanDecoder::GetAlgaeAngleDegrees() {
-    return -(m_algaeAngleDegrees - kAlgaeAngleOffsetDegrees);
+    return m_algaeAngleDegrees - kAlgaeAngleOffsetDegrees;
 }
 
 float FeatherCanDecoder::GetAlgaeRawAngleDegrees() {
@@ -119,7 +119,7 @@ void FeatherCanDecoder::UnpackCoralCANData() {
 void FeatherCanDecoder::UnpackAlgaeCANData() {
     frc::CANData data;
 
-    bool isAlgaeDataValid = m_algaeCAN.ReadPacketNew(kAlgaeAPIId, &data);
+    bool isAlgaeDataValid = m_algaeCAN.ReadPacketTimeout(kAlgaeAPIId, kCANReadTimeoutMs, &data);
     frc::SmartDashboard::PutBoolean("is algae data valid", isAlgaeDataValid);
 
     if (isAlgaeDataValid) {
@@ -136,6 +136,8 @@ void FeatherCanDecoder::UnpackAlgaeCANData() {
             m_algaeCollected = proximity > kAlgaeProximityThreshold;
         }
     }
+
+    m_algaeAngleValid = isAlgaeDataValid;
 }
 
 void FeatherCanDecoder::UnpackClimberCANData() {

--- a/src/main/cpp/subsystems/AlgaeSubsystem.cpp
+++ b/src/main/cpp/subsystems/AlgaeSubsystem.cpp
@@ -7,32 +7,23 @@
 
 AlgaeSubsystem::AlgaeSubsystem(IAlgaeDataProvider* dataProvider):
 m_algaePivotMotor(kAlgaePivot),
-m_algaeLeftMotor{kAlgaeMotorLeft, rev::spark::SparkLowLevel::MotorType::kBrushless},
-// m_algaeRightMotor{kAlgaeMotorRight, rev::spark::SparkLowLevel::MotorType::kBrushless},
+m_algaeMotor{kAlgaeMotor, rev::spark::SparkLowLevel::MotorType::kBrushless},
 m_algaeDataProvider(dataProvider)
 {
-    rev::spark::SparkBaseConfig config;
-    config.Follow(kAlgaeMotorRight, true);
-    config.Inverted(true);
-
-    // m_algaeLeftMotor.Configure(config,
-    //     rev::spark::SparkBase::ResetMode::kResetSafeParameters,
-    //     rev::spark::SparkBase::PersistMode::kPersistParameters
-    // );
 }
 
 void AlgaeSubsystem::Periodic() {
-    // GoToAngle();
+    GoToAngle();
     frc::SmartDashboard::PutNumber("Algae Angle", CurrentAngle().value());
 }
 
 frc2::CommandPtr AlgaeSubsystem::Intake() {
     return frc2::cmd::StartEnd(
         [this] {
-            // m_algaeRightMotor.Set(0.4);
+            m_algaeMotor.Set(0.4);
         },
         [this] {
-            // m_algaeRightMotor.Set(0.0);
+            m_algaeMotor.Set(0.0);
         }
     ).Until(
         [this] {
@@ -45,10 +36,10 @@ frc2::CommandPtr AlgaeSubsystem::Intake() {
 frc2::CommandPtr AlgaeSubsystem::Dispense() {
     return frc2::cmd::StartEnd(
         [this] {
-            // m_algaeRightMotor.Set(-0.4);
+            m_algaeMotor.Set(-0.4);
         },
         [this] {
-            // m_algaeRightMotor.Set(0.0);
+            m_algaeMotor.Set(0.0);
         }
     ).WithTimeout(2_s);
 }

--- a/src/main/cpp/subsystems/AlgaeSubsystem.cpp
+++ b/src/main/cpp/subsystems/AlgaeSubsystem.cpp
@@ -41,7 +41,7 @@ frc2::CommandPtr AlgaeSubsystem::Dispense() {
         [this] {
             m_algaeMotor.Set(0.0);
         }
-    ).WithTimeout(2_s);
+    ).WithTimeout(5_s);
 }
 
 frc2::CommandPtr AlgaeSubsystem::SetGoalAngle(units::degree_t angle) {

--- a/src/main/cpp/subsystems/ElevatorSubsystem.cpp
+++ b/src/main/cpp/subsystems/ElevatorSubsystem.cpp
@@ -37,6 +37,10 @@ m_elevatorMotor2(kElevatorMotor2Id)
         .OnFalse(frc2::InstantCommand([this] {
             frc::SmartDashboard::PutBoolean("Elevator Limit Switch", false);
         }).ToPtr());
+
+    // Prevent excessive wind-up in the integral feedback of the PID controller that can build up when
+    // the bot is disabled.
+    m_elevatorPID.SetIntegratorRange(-0.4, 0.4);
 };
 
 void ElevatorSubsystem::Periodic() {
@@ -79,8 +83,8 @@ void ElevatorSubsystem::SetMotorVoltage() {
     units::volt_t goalVolts = units::volt_t(value) + m_feedforward.Calculate(m_elevatorPID.GetSetpoint().velocity);
     frc::SmartDashboard::PutNumber("Elevator PID with feedforward", goalVolts.value());
 
-    double current_difference = fabs(m_setpointHeight.value() - CurrentHeight().value());
-    if (current_difference >= TOLERANCE) {
+    units::inch_t current_difference = units::math::abs(m_setpointHeight - CurrentHeight());
+    if (current_difference >= kSetpointTolerance) {
         m_elevatorMotor1.SetVoltage(goalVolts);
         m_elevatorMotor2.SetVoltage(goalVolts);
     } else if (m_setpointHeight <= 0.2_in) {
@@ -91,14 +95,14 @@ void ElevatorSubsystem::SetMotorVoltage() {
         m_elevatorMotor2.SetVoltage(kG);
     }
 
-    m_elevatorAtHeight = (current_difference < kCloseEnoughToMove);
-    frc::SmartDashboard::PutBoolean("Elevator At Height", m_elevatorAtHeight);
+    m_closeEnoughToMove = (current_difference < kCloseEnoughToMove);
+    frc::SmartDashboard::PutBoolean("Elevator At Height", m_closeEnoughToMove);
 }
 
 frc2::CommandPtr ElevatorSubsystem::GoToHeight(units::inch_t height) {
     return frc2::cmd::RunOnce([this, height] {
         m_setpointHeight = height;
-        m_elevatorAtHeight = false;
+        m_closeEnoughToMove = false;
     });
 }
 
@@ -106,6 +110,6 @@ bool ElevatorSubsystem::GetElevatorHeightAboveThreshold() {
     return CurrentHeight() >= kHeightThreshold;
 }
 
-frc2::CommandPtr ElevatorSubsystem::WaitUntilElevatorAtHeight() {
-    return frc2::cmd::WaitUntil([this] { return m_elevatorAtHeight; });
+frc2::CommandPtr ElevatorSubsystem::WaitUntilElevatorIsCloseEnoughToMove() {
+    return frc2::cmd::WaitUntil([this] { return m_closeEnoughToMove; });
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -146,7 +146,8 @@ frc2::CommandPtr ScoringSuperstructure::ToCollectPosition() {
 frc2::CommandPtr ScoringSuperstructure::ToStowPosition() {
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorStowPosition),
-        m_coral.GoToAngle(kCoralStow)
+        m_coral.GoToAngle(kCoralStow),
+        m_algae.SetGoalAngle(kAlgaeStowAngle)
     );
 }
 

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -26,7 +26,7 @@ frc2::CommandPtr ScoringSuperstructure::PrepareScoring(ScoringSelector selectedS
 
 frc2::CommandPtr ScoringSuperstructure::DispenseCoralAndMoveBack() {
     return frc2::cmd::Sequence(
-        m_elevator.WaitUntilElevatorAtHeight(),
+        m_elevator.WaitUntilElevatorIsCloseEnoughToMove(),
         DriveForwardToScore(&m_drivetrain).WithTimeout(2.0_s),
         m_coral.Dispense(),
         DriveBackAfterScore(&m_drivetrain).WithTimeout(kBackupTimeout),
@@ -106,7 +106,7 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL4() {
         m_elevator.GoToHeight(kElevatorL4Position),
         m_coral.GoToAngle(coralAngle),
         DispenseCoralAndMoveBack()
-    ).AndThen(m_elevator.WaitUntilElevatorAtHeight().WithTimeout(2.0_s));
+    ).AndThen(m_elevator.WaitUntilElevatorIsCloseEnoughToMove().WithTimeout(2.0_s));
 }
 
 frc2::CommandPtr ScoringSuperstructure::ScoreIntoProcessor() {
@@ -115,7 +115,7 @@ frc2::CommandPtr ScoringSuperstructure::ScoreIntoProcessor() {
             m_elevator.GoToHeight(kElevatorProcessorPosition),
             m_algae.SetGoalAngle(kAlgaeExtendedAngle)
         ),
-        m_elevator.WaitUntilElevatorAtHeight(),
+        m_elevator.WaitUntilElevatorIsCloseEnoughToMove(),
         m_algae.Dispense()
     ).OnlyIf([this] { return m_algae.IsAlgaeStored(); });
 }
@@ -151,5 +151,5 @@ frc2::CommandPtr ScoringSuperstructure::ToStowPosition() {
 }
 
 frc2::CommandPtr ScoringSuperstructure::WaitTillElevatorAtHeight() {
-    return m_elevator.WaitUntilElevatorAtHeight();
+    return m_elevator.WaitUntilElevatorIsCloseEnoughToMove();
 }

--- a/src/main/cpp/subsystems/ScoringSuperstructure.cpp
+++ b/src/main/cpp/subsystems/ScoringSuperstructure.cpp
@@ -53,7 +53,7 @@ frc2::CommandPtr ScoringSuperstructure::ScoreIntoReef() {
         },
         std::pair{L1, ScoreReefL1()},
         std::pair{L2, ScoreReefL2()},
-        std::pair{L3AlgaeAndCoral, ScoreReefL3(false)},
+        std::pair{L3AlgaeAndCoral, ScoreReefL3(true)},
         std::pair{L3AlgaeOnly, ScoreReefL3(true)},
         std::pair{L4, ScoreReefL4()});
 }
@@ -78,22 +78,21 @@ frc2::CommandPtr ScoringSuperstructure::ScoreReefL2() {
     );
 }
 
-frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool algaeOnly) {
+frc2::CommandPtr ScoringSuperstructure::ScoreReefL3(bool removeAlgae) {
     auto [coralAngle, algaeAngle] = m_elevatorMap[kElevatorL3Position];
 
     return frc2::cmd::Parallel(
         m_elevator.GoToHeight(kElevatorL3Position),
         m_coral.GoToAngle(coralAngle),
 
-        // @note Disabling all algae for Friday
-        // frc2::cmd::Either(
-        //     frc2::cmd::Sequence(
-        //         m_algae.SetGoalAngle(kAlgaeExtendedAngle),
-        //         m_algae.Intake()
-        //     ),
-        //     m_algae.SetGoalAngle(algaeAngle),
-        //     [this, algaeOnly] { return algaeOnly; }
-        // ),
+        frc2::cmd::Either(
+            frc2::cmd::Sequence(
+                m_algae.SetGoalAngle(kAlgaeExtendedAngle),
+                m_algae.Dispense()
+            ),
+            m_algae.SetGoalAngle(kAlgaeStowAngle),
+            [this, removeAlgae] { return removeAlgae; }
+        ),
 
         DispenseCoralAndMoveBack()
     );

--- a/src/main/include/commands/DriveBackAfterScore.h
+++ b/src/main/include/commands/DriveBackAfterScore.h
@@ -26,15 +26,18 @@ public:
 private:
     subsystems::CommandSwerveDrivetrain* m_drivetrain;
 
-    swerve::requests::RobotCentric robotOriented = swerve::requests::RobotCentric{}
-        .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
-        .WithVelocityY(0_mps)
-        .WithRotationalRate(0_rad_per_s);
-
     static constexpr double kP = 1.0;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
     static constexpr units::meters_per_second_t kMaxVelocity = 1.0_mps;
+
+    // Apply a slight shift to the left while driving back to pull out an algae
+    static constexpr units::meters_per_second_t kLeftShift = 0.3_mps;
+
+    swerve::requests::RobotCentric robotOriented = swerve::requests::RobotCentric{}
+        .WithDriveRequestType(swerve::DriveRequestType::OpenLoopVoltage)
+        .WithVelocityY(kLeftShift)
+        .WithRotationalRate(0_rad_per_s);
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -34,7 +34,7 @@ private:
     static constexpr double kP = 0.9;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
-    static constexpr units::meters_per_second_t kMaxVelocity = 1.25_mps;
+    static constexpr units::meters_per_second_t kMaxVelocity = 1.0_mps;
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 

--- a/src/main/include/commands/DriveForwardToScore.h
+++ b/src/main/include/commands/DriveForwardToScore.h
@@ -31,10 +31,10 @@ private:
         .WithVelocityY(0_mps)
         .WithRotationalRate(0_rad_per_s);
 
-    static constexpr double kP = 1.0;
+    static constexpr double kP = 0.9;
     static constexpr double kI = 0.0;
     static constexpr double kD = 0.0;
-    static constexpr units::meters_per_second_t kMaxVelocity = 0.75_mps;
+    static constexpr units::meters_per_second_t kMaxVelocity = 1.25_mps;
 
     frc::PIDController m_XAlignmentPID {kP, kI, kD};
 

--- a/src/main/include/io/FeatherCanDecoder.h
+++ b/src/main/include/io/FeatherCanDecoder.h
@@ -25,7 +25,7 @@ public:
     const int kAlgaeDeviceID = 2;
     const int kAlgaeAPIId = 2;
     const int kAlgaeProximityThreshold = 1500;
-    const double kAlgaeAngleOffsetDegrees = 47.5;
+    const double kAlgaeAngleOffsetDegrees = -237.6;
 
     const int kClimberDeviceID = 3;
     const int kClimberAPIId = 3;
@@ -84,6 +84,7 @@ private:
     void UnpackCoralCANData();
 
     float m_algaeAngleDegrees;
+    bool m_algaeAngleValid;
     bool m_algaeCollected;
     frc::CAN m_algaeCAN;
 

--- a/src/main/include/subsystems/AlgaeSubsystem.h
+++ b/src/main/include/subsystems/AlgaeSubsystem.h
@@ -15,8 +15,7 @@
 #include <units/velocity.h>
 #include <units/acceleration.h>
 
-constexpr int kAlgaeMotorLeft = 49;
-constexpr int kAlgaeMotorRight = 50;
+constexpr int kAlgaeMotor = 49;
 constexpr int kAlgaePivot = 35;
 
 constexpr units::degree_t kAlgaeStowAngle = 150.0_deg;
@@ -40,14 +39,13 @@ class AlgaeSubsystem : public frc2::SubsystemBase {
 
     ctre::phoenix6::hardware::TalonFX m_algaePivotMotor;
 
-    rev::spark::SparkMax m_algaeLeftMotor;
-    // rev::spark::SparkMax m_algaeRightMotor;
+    rev::spark::SparkMax m_algaeMotor;
 
     static constexpr units::turns_per_second_t kMaxVelocity = 1.5_tps;
     static constexpr units::turns_per_second_squared_t kMaxAcceleration = 0.75_tr_per_s_sq;
-    static constexpr double kP = 12;
+    static constexpr double kP = 15.0;
     static constexpr double kI = 0.0;
-    static constexpr double kD = 1.0;
+    static constexpr double kD = 0.0;
 
     static constexpr units::volt_t kS = 0.25_V;
     static constexpr units::volt_t kG = 0.0_V;

--- a/src/main/include/subsystems/CoralSubsystem.h
+++ b/src/main/include/subsystems/CoralSubsystem.h
@@ -8,7 +8,7 @@
 #include <frc/controller/PIDController.h>
 #include "subsystems/ICoralIntakeDataProvider.h"
 
-constexpr units::degree_t kCoralCollect = 137.5_deg;
+constexpr units::degree_t kCoralCollect = 135_deg;
 constexpr units::degree_t kCoralStow = 157_deg;
 constexpr units::degree_t kCoralL1 = 65.0_deg;
 constexpr units::degree_t kCoralL2 = 55.0_deg;

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -82,7 +82,7 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
         static constexpr double kI = 0.5;
         static constexpr double kD = 2.0;
         static constexpr units::volt_t kS = 0.325_V;
-        static constexpr units::volt_t kG = 0.25_V;
+        static constexpr units::volt_t kG = 0.35_V;
         static constexpr auto kV = 0.0_V / 1.0_mps;
 
         frc::TrapezoidProfile<units::meters>::Constraints m_constraints {

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -55,12 +55,12 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
             return GetElevatorHeightAboveThreshold();
         });
 
-        frc2::CommandPtr WaitUntilElevatorAtHeight();
+        frc2::CommandPtr WaitUntilElevatorIsCloseEnoughToMove();
     private:
 
         bool GetElevatorHeightAboveThreshold();
 
-        bool m_elevatorAtHeight = false;
+        bool m_closeEnoughToMove = false;
 
         ctre::phoenix6::hardware::TalonFX m_elevatorMotor1;
         ctre::phoenix6::hardware::TalonFX m_elevatorMotor2;
@@ -72,14 +72,9 @@ class ElevatorSubsystem : public frc2::SubsystemBase {
             return !m_elevatorLimitSwitch.Get();
         });
 
-        static constexpr double TOLERANCE = 0.5;
-        static constexpr double kCloseEnoughToMove = 1.5;
+        static constexpr units::inch_t kSetpointTolerance = 0.5_in;
+        static constexpr units::inch_t kCloseEnoughToMove = 4_in;
 
-        // @todo Re-adjust the elevator speeds. We slowed them down because raising
-        //  lowering wasn't very smooth in recent tests. It's still unclear what
-        //  is causing that.
-        // static constexpr units::meters_per_second_t kMaxVelocity = 5.0_mps;
-        // static constexpr units::meters_per_second_squared_t kMaxAcceleration = 8.0_mps_sq;
         static constexpr units::meters_per_second_t kMaxVelocity = 5.0_mps;
         static constexpr units::meters_per_second_squared_t kMaxAcceleration = 8.0_mps_sq;
         static constexpr double kP = 20.0;

--- a/src/main/include/subsystems/ElevatorSubsystem.h
+++ b/src/main/include/subsystems/ElevatorSubsystem.h
@@ -27,6 +27,7 @@ constexpr units::inch_t kElevatorProcessorPosition = 10_in;
 constexpr units::inch_t kElevatorL1Position = 0_in;
 constexpr units::inch_t kElevatorL2Position = 13_in;
 constexpr units::inch_t kElevatorL3Position = 28_in;
+constexpr units::inch_t kElevatorAlgaeOnlyL3Position = 44_in;
 constexpr units::inch_t kElevatorL4Position = 61.5_in;
 
 constexpr float kSlowElevator = 0.6;


### PR DESCRIPTION
This incorporates several things that we had talked about before and also re-adds the algae mechanism. The work you all did with the commands in the ScoringSuperstructure made re-adding the algae a breeze. Thank you for that!

* Added controls for the new single arm algae mechanism
* Fixed the angle offset after the algae through bore encoder was added back
* Added the beginnings of being able to ignore the algae angle if we stop receiving data from the algae FeatherCAN
* Added a slight shift to the left when backing up to be sure the algae wheel catches the algae
  - Note for @CMalohn16 : Pretty sure this breaks the distance calculation. Sorry about that! Can you and/or someone have a look to see if there's a way to do that better? We can talk about it in person if that'll be easier.
* Put in a different tolerance for the elevator for when it is considered close enough to move (hopefully to speed up the auto sequence)